### PR TITLE
Force GUI askpass to solve #6

### DIFF
--- a/autoload/gina/core/askpass.vim
+++ b/autoload/gina/core/askpass.vim
@@ -1,0 +1,81 @@
+let s:Config = vital#gina#import('Config')
+let s:Console = vital#gina#import('Vim.Console')
+let s:Path = vital#gina#import('System.Filepath')
+
+let s:is_windows = has('win32') || has('win64')
+let s:is_darwin = has('mac') || has('macunix')
+let s:repository_root = expand('<sfile>:p:h:h:h:h')
+let s:askpass_script = s:Path.join(s:repository_root, 'scripts', 'askpass')
+
+if s:is_windows
+  " win-ssh-askpass may help?
+  " https://sourceforge.net/projects/winsshaskpass/
+  let s:askpass_script = ''
+elseif s:is_darwin
+  " AFAI, no usable GUI ssh-askpass exist
+  let s:askpass_script .= '.mac'
+else
+  if executable('zenity')
+    let s:askpass_script .= '.zenity'
+  else
+    " ssh-askpass-gnome would help in this case
+    let s:askpass_script = ''
+  endif
+endif
+
+if s:is_windows
+  function! gina#core#askpass#wrap(git, args) abort
+    if empty($GIT_TERMINAL_PROMPT) && !g:gina#core#askpass#suppress_warning
+      call s:Console.warn('$GIT_TERMINAL_PROMPT has not configured.')
+      call s:Console.warn('The environment variable should be configured.')
+      call s:Console.warn('See :h gina-askpass-windows')
+    endif
+    " NOTE:
+    " Windows does not have 'env' like application so use '-c core.askpass'
+    " instead of '$GIT_ASKPASS' environment variable
+    let askpass = s:askpass(a:git)
+    if !empty(askpass)
+      call insert(a:args.raw, ['-c', 'core.askpass=' . askpass], 1)
+    endif
+    return a:args
+  endfunction
+else
+  function! gina#core#askpass#wrap(git, args) abort
+    let prefix = ['env', 'GIT_TERMINAL_PROMPT=0']
+    let askpass = s:askpass(a:git)
+    if !empty(askpass)
+      " NOTE:
+      " '$GIT_ASKPASS' has a higest priority so use this instead of
+      " '-c core.askpass=...' in Mac/Linux environment while 'env'
+      " is available.
+      let prefix += ['GIT_ASKPASS=' . askpass]
+    endif
+    let a:args.raw = prefix + a:args.raw
+    return a:args
+  endfunction
+endif
+
+
+function! s:askpass(git) abort
+  let config = gina#core#repo#config(a:git)
+  let askpass = get(get(config, 'core', {}), 'askpass')
+  if !empty(g:gina#core#askpass#askpass_program)
+    return g:gina#core#askpas#askpass_program
+  elseif g:gina#core#askpass#force_internal_script
+    return s:askpass_script
+  elseif exists('$GIT_ASKPASS')
+    return $GIT_ASKPASS
+  elseif !empty(askpass)
+    return askpass
+  elseif exists('$SSH_ASKPASS')
+    return $SSH_ASKPASS
+  endif
+  return s:askpass_script
+endfunction
+
+
+call s:Config.define('g:gina#core#askpass', {
+      \ 'askpass_program': '',
+      \ 'force_internal_script': 0,
+      \ 'suppress_warning': 1,
+      \})

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -18,6 +18,7 @@ Interface			|gina-interface|
   Functions			|gina-functions|
   Options			|gina-options|
   Actions			|gina-actions|
+ASKPASS				|gina-askpass|
 
 
 =============================================================================
@@ -612,6 +613,107 @@ show:right
 show:tab
 show:preview
 	Show a content in the index or the commit.
+
+=============================================================================
+ASKPASS						*gina-askpass*
+
+When git requires username or password (e.g. git pull on a repository linked
+with https://), it use a program called "askpass".
+While gina.vim execute a git command through a job feature, a terminal based
+askpass program which git provides cannot be used.
+To solve this issue, gina.vim try to use a GUI based askpass program instead.
+
+-----------------------------------------------------------------------------
+LINUX						*gina-askpass-linux*
+
+There is a well known GUI based askpass program called "ssh-askpass-gnome".
+Users should install the program and set the executable path to one of these
+
+1. "$GIT_ASKPASS" environment variable
+2. "core.askpass" with "git config --global core.askpass=..."
+3. "$SSH_ASKPASS" environment variable
+
+When no available askpass program could be detected from above, gina.vim use
+an internal askpass script based on "zenity" when "zenity" is executable.
+Otherwise a git command which requires username and/or password always fail.
+
+In short, Linux users should do one of
+
+- Install "ssh-askpass-gnome" and configure it properly
+- Install "zenity"
+
+To enable username and/or password interactive input.
+
+See "scripts/askpass.zenity" if you would like to check what the script does.
+
+-----------------------------------------------------------------------------
+MAC						*gina-askpass-mac*
+
+gina.vim provides an internal askpass script based on an AppleScript.
+The script should be available on any Unix based Mac.
+
+In short, Mac uses should do nothing to enable username and/or password
+interactive input.
+
+See "scripts/askpass.mac" if you would like to check what the script does.
+
+-----------------------------------------------------------------------------
+WINDOWS						*gina-askpass-windows*
+
+There is a GUI based askpass program called "win-ssh-askpass".
+Users should install the program and set executable path to one of these
+
+1. "$GIT_ASKPASS" environment variable
+2. "core.askpass" with "git config --global core.askpass=..."
+3. "$SSH_ASKPASS" environment variable
+
+When no available askpass program could be detected from above, gina.vim use
+an internal askpass script (Not implemented yet).
+Otherwise a git command which requires username and/or password always fail.
+
+Additionally, while Windows does not provide Unix's "env" like command, users
+should set "$GIT_TERMINAL_PROMPT" environment variable to "0" by themselves.
+See |gina-askpass-GIT_TERMINAL_PROMPT| for more detail.
+
+In short, Windows users should
+
+1. Install "win-ssh-askpass" and configure it properly
+2. Add "let $GIT_TERMINAL_PROMPT = '0'" to somewhere in your vimrc
+
+To enable username and/or password interactive input.
+
+-----------------------------------------------------------------------------
+GIT_TERMINAL_PROMPT			 *gina-askpass-GIT_TERMINAL_PROMPT*
+
+A git fallback to use a builtin terminal based askpass program when git
+failed to use a specified askpass OR when a specified askpass program returns
+an empty value.
+So the terminal based askpass program will called when user cancel GUI based
+askpass program and gina.vim cannot treat the terminal based askpass program
+correctly.
+So users should set "$GIT_TERMINAL_PROMPT = 0" to tell git to disable the
+terminal based askpass program.
+
+In Unix-like platform (Linux/Mac), it is configured by gina.vim automatically
+while an "env" command is available on this platform to temporary set the
+environment variable. So users do not need to consider about this.
+
+In Windows, it is not configured automatically due to the lack of "env" like
+program on this platform. So users SHOULD configure this environment variable
+by themselves.
+
+However $GIT_TERMINAL_PROMPT disable a terminal based askpass program,
+indicating that configure it without assinging a proper askpass program to
+$GIT_ASKPASS, core.askpass, or $SSH_ASKPASS would make it impossible to input
+username and/or password when git requires.
+That's why the $GIT_TERMINAL_PROMPT should be configured only in the Vim's
+live session. To do that, use |let-$| syntax to configure it in Vim like
+>
+	let $GIT_TERMINAL_PROMPT = "0"
+<
+Note that :terminal command in Neovim or :VimShell command provided by
+Shougo/vimshell.vim would be effected by the setting above as well.
+
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -660,59 +660,12 @@ See "scripts/askpass.mac" if you would like to check what the script does.
 -----------------------------------------------------------------------------
 WINDOWS						*gina-askpass-windows*
 
-There is a GUI based askpass program called "win-ssh-askpass".
-Users should install the program and set executable path to one of these
+Git has a built-in credential helper called "wincred" for Windows.
+This credential helper use a GUI-based prompt so Windows user do not need to
+worry about this unless they disabled that by configuration.
 
-1. "$GIT_ASKPASS" environment variable
-2. "core.askpass" with "git config --global core.askpass=..."
-3. "$SSH_ASKPASS" environment variable
-
-When no available askpass program could be detected from above, gina.vim use
-an internal askpass script (Not implemented yet).
-Otherwise a git command which requires username and/or password always fail.
-
-Additionally, while Windows does not provide Unix's "env" like command, users
-should set "$GIT_TERMINAL_PROMPT" environment variable to "0" by themselves.
-See |gina-askpass-GIT_TERMINAL_PROMPT| for more detail.
-
-In short, Windows users should
-
-1. Install "win-ssh-askpass" and configure it properly
-2. Add "let $GIT_TERMINAL_PROMPT = '0'" to somewhere in your vimrc
-
-To enable username and/or password interactive input.
-
------------------------------------------------------------------------------
-GIT_TERMINAL_PROMPT			 *gina-askpass-GIT_TERMINAL_PROMPT*
-
-A git fallback to use a builtin terminal based askpass program when git
-failed to use a specified askpass OR when a specified askpass program returns
-an empty value.
-So the terminal based askpass program will called when user cancel GUI based
-askpass program and gina.vim cannot treat the terminal based askpass program
-correctly.
-So users should set "$GIT_TERMINAL_PROMPT = 0" to tell git to disable the
-terminal based askpass program.
-
-In Unix-like platform (Linux/Mac), it is configured by gina.vim automatically
-while an "env" command is available on this platform to temporary set the
-environment variable. So users do not need to consider about this.
-
-In Windows, it is not configured automatically due to the lack of "env" like
-program on this platform. So users SHOULD configure this environment variable
-by themselves.
-
-However $GIT_TERMINAL_PROMPT disable a terminal based askpass program,
-indicating that configure it without assinging a proper askpass program to
-$GIT_ASKPASS, core.askpass, or $SSH_ASKPASS would make it impossible to input
-username and/or password when git requires.
-That's why the $GIT_TERMINAL_PROMPT should be configured only in the Vim's
-live session. To do that, use |let-$| syntax to configure it in Vim like
->
-	let $GIT_TERMINAL_PROMPT = "0"
-<
-Note that :terminal command in Neovim or :VimShell command provided by
-Shougo/vimshell.vim would be effected by the setting above as well.
+In short, use "git config --global credential.helper wincred" to use
+"wincred" in your system.
 
 
 =============================================================================

--- a/scripts/askpass.mac
+++ b/scripts/askpass.mac
@@ -1,0 +1,35 @@
+#!/usr/bin/env osascript
+#---------------------------------------------------------------------------------------
+# git askpass via AppleScript (For macOS)
+#
+# Author:	lambdalisue <lambdalisue@hashnote.net>
+# License:	MIT License
+#
+# Usage:
+#	git config --global core.askpass={path to this script}
+#
+# Reference:
+# 	http://blog.thefrontiergroup.com.au/2008/12/prompting-for-a-password-with-applescript/
+# 	http://stackoverflow.com/questions/15605288/print-to-stdout-with-applescript
+# 	https://github.com/git/git/blob/35f6318d44379452d8d33e880d8df0267b4a0cd0/prompt.c#L7
+#---------------------------------------------------------------------------------------
+on run argv
+	set prompt to (item 1 of argv)
+	if prompt contains "Username"
+		set input to display dialog prompt ¬
+			with title "Username" ¬
+			with icon caution ¬
+			default answer "" ¬
+			buttons {"Cancel", "OK"} default button 2 ¬
+			giving up after 295
+	else
+		set input to display dialog prompt ¬
+			with title "Password" ¬
+			with icon caution ¬
+			default answer "" ¬
+			buttons {"Cancel", "OK"} default button 2 ¬
+			giving up after 295 ¬
+			with hidden answer
+	end if
+	return the text returned of the input
+end run

--- a/scripts/askpass.zenity
+++ b/scripts/askpass.zenity
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#---------------------------------------------------------------------------------------
+# git askpass via zenity (For Linux)
+#
+# Author:   lambdalisue <lambdalisue@hashnote.net>
+# License:  MIT License
+#
+# Usage:
+#   git config --global core.askpass={path to this script}
+#
+# Reference:
+#   https://help.gnome.org/users/zenity/stable/index.html.ja
+#   https://github.com/git/git/blob/35f6318d44379452d8d33e880d8df0267b4a0cd0/prompt.c#L7
+#---------------------------------------------------------------------------------------
+if ! type zenity >/dev/null 2>&1; then
+  (>&2 echo "zenity is not found. Please install it first.")
+  exit 1
+fi
+
+PROMPT=$1
+if [[ -z $PROMPT ]]; then
+  (>&2 echo "a first argument is not specified")
+  exit 1
+fi
+
+if [[ "$PROMPT" =~ Username ]]; then
+  zenity --entry \
+    --title="Username" \
+    --text="$PROMPT" \
+    2>/dev/null
+else
+  zenity --entry \
+    --title="Password" \
+    --text="$PROMPT" \
+    --hide-text \
+    2>/dev/null
+fi

--- a/test/gina/command/log.vimspec
+++ b/test/gina/command/log.vimspec
@@ -21,7 +21,7 @@ Describe gina#command#log
         Gina log
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname('%'), 'gina://valid1:log')
-        Assert Equals(line('$'), 2, 'There should be two commits')
+        Assert Equals(line('$'), 2, 'There should be two commits but the content was ' . join(getline(1, '$'), "\n"))
       End
 
       It opens a commit info under the cursor with 'info' action
@@ -38,7 +38,7 @@ Describe gina#command#log
         Gina log -- %
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname('%'), 'gina://valid1:log/:A/foo')
-        Assert Equals(line('$'), 1, 'There should be one commits')
+        Assert Equals(line('$'), 1, 'There should be one commit but the content was ' . join(getline(1, '$'), "\n"))
       End
 
       It opens a content of the file on the commit under the cursor with 'info' action
@@ -66,7 +66,7 @@ Describe gina#command#log
         Gina log
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname('%'), 'gina://valid2:log')
-        Assert Equals(line('$'), 2, 'There should be two commits')
+        Assert Equals(line('$'), 2, 'There should be two commits but the content was ' . join(getline(1, '$'), "\n"))
       End
 
       It opens a commit under the cursor with 'show' action
@@ -89,7 +89,7 @@ Describe gina#command#log
         Gina log -- %
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname('%'), 'gina://valid2:log/:A/foo')
-        Assert Equals(line('$'), 1, 'There should be one commits')
+        Assert Equals(line('$'), 1, 'There should be one commit but the content was ' . join(getline(1, '$'), "\n"))
       End
 
       It opens a content of the file on the commit under the cursor with 'show' action


### PR DESCRIPTION
It seems a CUI based askpass which git provides (['get_terminal_prompt'](https://github.com/git/git/blob/35f6318d44379452d8d33e880d8df0267b4a0cd0/prompt.c#L64) in git code) does not works properly in job process.
To fix the issue (issue #6), this commit disable CUI based prompt via $GIT_TERMINAL_PROMPT=0 and try to use GUI based prompt.

Linux:
User should assign 'gnome-ssh-askpass' to '$GIT_ASKPASS', 'git config --global core.askpass', or '$SSH_ASKPASS'.
If non of settings exist, it use a gina's internal askpass script when 'zenity' is available.
Otherwise an operation which requires askpass always fail.
Note that users may need to specify an absolute path. Use `locate gnome-ssh-askpass` then.

Mac:
AFIK, there is no usable GUI based askpass exists on Mac. However, a gina's internal askpass script should works fine on any Mac environment.
If non of settings exist, it use a gina's internal askpass script which use AppleScript internally.

Windows:
It seems 'win-ssh-askpass' exists for this purpose.
User can try to assign that to '$GIT_ASKPASS', 'git config --global core.askpass', or '$SSH_ASKPASS'.
If non of settings exist, an operation which requires askpass always fail while there is no gina's internal script because I don't know Windows well enough. (**PR or snippet or any suggestions for making an internal script for Windows is welcome**)