### PR TITLE
RFC: Add 'blame' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,10 @@ Missings
 
 The following features are planned but missing for now
 
-- [ ] Command completions
-- [ ] Component system for statusline/tabline like vim-gita has
-- [ ] Blame interface like `:Gita blame` of vim-gita
-- [ ] Interface for `git stash`
-- [ ] Actions for `reflog` and `tag`
+- Command completions
+- Component system for statusline/tabline like vim-gita has
+- Interface for `git stash`
+- Actions for `reflog` and `tag`
 
 Pros.
 -------------------------------------------------------------------------------

--- a/autoload/gina/action/blame.vim
+++ b/autoload/gina/action/blame.vim
@@ -74,7 +74,8 @@ function! s:on_open(candidates, options) abort dict
   call s:add_history()
   let treeish = gina#core#treeish#build(rev, path)
   execute printf(
-        \ 'Gina blame %s %s %s',
+        \ '%s Gina blame %s %s %s',
+        \ options.mods,
         \ gina#util#shellescape(options.opener, '--opener='),
         \ gina#util#shellescape(line, '--line='),
         \ gina#util#shellescape(treeish),
@@ -88,7 +89,8 @@ function! s:on_back(candidates, options) abort dict
   let history = s:pop_history()
   let treeish = gina#core#treeish#build(history.rev, history.path)
   execute printf(
-        \ 'Gina blame %s %s %s',
+        \ '%s Gina blame %s %s %s',
+        \ options.mods,
         \ gina#util#shellescape(options.opener, '--opener='),
         \ gina#util#shellescape(history.line, '--line='),
         \ gina#util#shellescape(treeish),

--- a/autoload/gina/action/blame.vim
+++ b/autoload/gina/action/blame.vim
@@ -20,11 +20,11 @@ function! gina#action#blame#define(binder) abort
           \ 'description': 'Echo the chunk info',
           \ 'mapping_mode': 'n',
           \ 'requirements': [
-          \   'rev',
           \   'summary',
           \   'author',
           \   'author_time',
           \   'author_tz',
+          \   'revision',
           \ ],
           \ 'options': {},
           \})
@@ -38,21 +38,7 @@ function! s:on_echo(candidates, options) abort dict
     return
   endif
   let chunk = a:candidates[0]
-  let timestamp = gina#command#blame#timestamper#new().format(
-        \ chunk.author_time,
-        \ chunk.author_tz,
-        \)
-  let revision = chunk.rev
-  if has_key(chunk, 'previous')
-    let revision = printf('%s <- %s', revision, chunk.previous)
-  endif
-  redraw | call gina#core#console#info(printf(
-        \ '%s by %s %s (%s)',
-        \ chunk.summary,
-        \ chunk.author,
-        \ timestamp,
-        \ revision,
-        \))
+  call gina#command#blame#echo(chunk)
 endfunction
 
 function! s:on_open(candidates, options) abort dict

--- a/autoload/gina/action/blame.vim
+++ b/autoload/gina/action/blame.vim
@@ -1,0 +1,118 @@
+let s:DateTime = vital#gina#import('DateTime')
+
+
+function! gina#action#blame#define(binder) abort
+  call a:binder.define('blame:open', function('s:on_open'), {
+        \ 'description': 'Blame a content or enter the blame chunk',
+        \ 'mapping_mode': 'n',
+        \ 'requirements': ['rev', 'path'],
+        \ 'options': {},
+        \})
+
+  if gina#core#buffer#param('%', 'scheme') ==# 'blame'
+    call a:binder.define('blame:back', function('s:on_back'), {
+          \ 'description': 'Back to a navigational previous blame',
+          \ 'mapping_mode': 'n',
+          \ 'requirements': [],
+          \ 'options': {},
+          \})
+    call a:binder.define('blame:echo', function('s:on_echo'), {
+          \ 'description': 'Echo the chunk info',
+          \ 'mapping_mode': 'n',
+          \ 'requirements': [
+          \   'rev',
+          \   'summary',
+          \   'author',
+          \   'author_time',
+          \   'author_tz',
+          \ ],
+          \ 'options': {},
+          \})
+  endif
+endfunction
+
+
+" Private --------------------------------------------------------------------
+function! s:on_echo(candidates, options) abort dict
+  if empty(a:candidates)
+    return
+  endif
+  let chunk = a:candidates[0]
+  let timestamp = gina#command#blame#timestamper#new().format(
+        \ chunk.author_time,
+        \ chunk.author_tz,
+        \)
+  let revision = chunk.rev
+  if has_key(chunk, 'previous')
+    let revision = printf('%s <- %s', revision, chunk.previous)
+  endif
+  redraw | call gina#core#console#info(printf(
+        \ '%s by %s %s (%s)',
+        \ chunk.summary,
+        \ chunk.author,
+        \ timestamp,
+        \ revision,
+        \))
+endfunction
+
+function! s:on_open(candidates, options) abort dict
+  if empty(a:candidates)
+    return
+  endif
+  let options = extend({
+        \ 'opener': '',
+        \}, a:options)
+  let args = gina#core#meta#get_or_fail('args')
+  let chunk = a:candidates[0]
+  if !empty(args.params.rev) && chunk.rev =~# '^' . args.params.rev
+    throw gina#core#exception#info(printf(
+          \ 'No related parent commit exists and "%s" is already shown',
+          \ chunk.rev,
+          \))
+  endif
+  call s:add_history()
+  let treeish = gina#core#treeish#build(chunk.rev, chunk.path)
+  execute printf(
+        \ 'Gina blame %s %s %s',
+        \ gina#util#shellescape(options.opener, '--opener='),
+        \ gina#util#shellescape(gina#util#get(chunk, 'line'), '--line='),
+        \ gina#util#shellescape(treeish),
+        \)
+endfunction
+
+function! s:on_back(candidates, options) abort dict
+  let options = extend({
+        \ 'opener': '',
+        \}, a:options)
+  let history = s:pop_history()
+  let treeish = gina#core#treeish#build(history.rev, history.path)
+  execute printf(
+        \ 'Gina blame %s %s %s',
+        \ gina#util#shellescape(options.opener, '--opener='),
+        \ gina#util#shellescape(history.line, '--line='),
+        \ gina#util#shellescape(treeish),
+        \)
+endfunction
+
+
+" History --------------------------------------------------------------------
+function! s:add_history() abort
+  if gina#core#buffer#param('%', 'scheme') !=# 'blame'
+    return
+  endif
+  let w:gina_blame_history = get(w:, 'gina_blame_history', [])
+  let args = gina#core#meta#get_or_fail('args')
+  call add(w:gina_blame_history, {
+        \ 'rev': empty(args.params.rev) ? ':0' : args.params.rev,
+        \ 'path': args.params.path,
+        \ 'line': line('.'),
+        \})
+endfunction
+
+function! s:pop_history() abort
+  let w:gina_blame_history = get(w:, 'gina_blame_history', [])
+  if empty(w:gina_blame_history)
+    throw gina#core#exception#info('No navigational history is found')
+  endif
+  return remove(w:gina_blame_history, -1)
+endfunction

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -1,0 +1,284 @@
+let s:Dict = vital#gina#import('Data.Dict')
+let s:Group = vital#gina#import('Vim.Buffer.Group')
+let s:Opener = vital#gina#import('Vim.Buffer.Opener')
+
+let s:SCHEME = gina#command#scheme(expand('<sfile>'))
+
+
+function! gina#command#blame#call(range, args, mods) abort
+  call gina#process#register(s:SCHEME, 1)
+  try
+    call s:call(a:range, a:args, a:mods)
+  finally
+    call gina#process#unregister(s:SCHEME, 1)
+  endtry
+endfunction
+
+
+" Private --------------------------------------------------------------------
+function! s:build_args(git, args) abort
+  let args = a:args.clone()
+  let args.params.groups = [
+        \ args.pop('--group1', 'blame-body'),
+        \ args.pop('--group2', 'blame-navi'),
+        \]
+  let args.params.opener = args.pop('--opener', 'edit')
+  let args.params.line = args.pop('--line', v:null)
+  let args.params.col = args.pop('--col', v:null)
+  let args.params.width = args.pop('--width', 30)
+
+  call gina#core#args#extend_treeish(a:git, args, args.pop(1))
+  if empty(args.params.path)
+    throw gina#core#exception#warn(printf(
+          \ 'No filename is specified. Did you mean "Gina blame %s:"?',
+          \ args.params.rev,
+          \))
+  endif
+
+  call args.pop('--porcelain')
+  call args.pop('--line-porcelain')
+  call args.set('--incremental', 1)
+  call args.set(1, substitute(args.params.rev, '^:0$', '', ''))
+  call args.residual([args.params.path])
+  return args.lock()
+endfunction
+
+function! s:call(range, args, mods) abort
+  let git = gina#core#get_or_fail()
+  let args = s:build_args(git, a:args)
+  let mods = gina#util#contain_direction(a:mods)
+        \ ? 'keepalt ' . a:mods
+        \ : join(['keepalt', 'rightbelow', a:mods])
+  let group = s:Group.new()
+
+  " Content
+  call s:open(mods, args.params.opener, args.params)
+  call group.add()
+  windo setlocal noscrollbind
+  setlocal scrollbind nowrap
+  augroup gina_command_blame_internal
+    autocmd! * <buffer>
+    autocmd WinLeave <buffer> call s:WinLeave()
+    autocmd WinEnter <buffer> call s:WinEnter()
+  augroup END
+  " Navi
+  let bufname = gina#core#buffer#bufname(git, 'blame', {
+        \ 'treeish': args.params.treeish,
+        \})
+  call gina#core#buffer#open(bufname, {
+        \ 'mods': 'leftabove',
+        \ 'group': args.params.groups[1],
+        \ 'opener': args.params.width . 'vsplit',
+        \ 'cmdarg': args.params.cmdarg,
+        \ 'range': 'all',
+        \ 'line': args.params.line,
+        \ 'callback': {
+        \   'fn': function('s:init'),
+        \   'args': [args],
+        \ }
+        \})
+  call group.add()
+  setlocal scrollbind
+  call gina#util#syncbind()
+  call gina#core#emitter#emit('command:called', s:SCHEME)
+endfunction
+
+function! s:open(mods, opener, params) abort
+  if s:Opener.is_preview_opener(a:opener)
+    throw gina#core#exception#warn(printf(
+          \ 'An opener "%s" is not allowed.',
+          \ a:opener,
+          \))
+  endif
+  let treeish = gina#core#treeish#build(a:params.rev, a:params.path)
+  execute printf(
+        \ '%s Gina show %s %s %s %s %s',
+        \ a:mods,
+        \ a:params.cmdarg,
+        \ gina#util#shellescape(a:opener, '--opener='),
+        \ gina#util#shellescape(a:params.groups[0], '--group='),
+        \ gina#util#shellescape(a:params.line, '--line='),
+        \ gina#util#shellescape(treeish),
+        \)
+endfunction
+
+function! s:init(args) abort
+  call gina#core#meta#set('args', a:args)
+
+  if exists('b:gina_initialized')
+    return
+  endif
+  let b:gina_initialized = 1
+
+  setlocal buftype=nofile
+  setlocal bufhidden=wipe
+  setlocal noswapfile
+  setlocal nomodifiable
+  " While navi must be vertical, set winfixwidth
+  setlocal winfixwidth
+
+  " Attach modules
+  call gina#action#attach(function('s:get_candidates'))
+  call gina#action#include('blame')
+  call gina#action#include('browse')
+  call gina#action#include('changes')
+  call gina#action#include('compare')
+  call gina#action#include('diff')
+  call gina#action#include('show')
+
+  augroup gina_command_blame_internal
+    autocmd! * <buffer>
+    autocmd BufReadCmd <buffer> call s:BufReadCmd()
+    autocmd VimResized <buffer> call s:VimResized()
+
+  augroup gina_command_blame_internal
+    autocmd! * <buffer>
+    autocmd BufReadCmd <buffer> call s:BufReadCmd()
+    autocmd VimResized <buffer> call s:VimResized()
+    autocmd WinLeave <buffer> call s:WinLeave()
+    autocmd WinEnter <buffer> call s:WinEnter()
+  augroup END
+endfunction
+
+function! s:WinLeave() abort
+  let bufname = bufname('%')
+  let scheme = gina#core#buffer#param(bufname, 'scheme')
+  let alternate = substitute(
+        \ bufname,
+        \ ':' . scheme . '\>',
+        \ ':' . (scheme ==# 'blame' ? 'show' : 'blame'),
+        \ ''
+        \)
+  if bufwinnr(alternate) > 0
+    call setbufvar(alternate, 'gina_syncbind_line', line('.'))
+  endif
+endfunction
+
+function! s:WinEnter() abort
+  if exists('b:gina_syncbind_line')
+    call setpos('.', [0, b:gina_syncbind_line, col('.'), 0])
+    unlet b:gina_syncbind_line
+  endif
+  syncbind
+endfunction
+
+function! s:BufReadCmd() abort
+  let git = gina#core#get_or_fail()
+  let args = gina#core#meta#get_or_fail('args')
+  let pipe = gina#command#blame#pipe#incremental()
+  let job = gina#process#open(git, args, pipe)
+  let status = job.wait()
+  if status
+    throw gina#process#errormsg({
+          \ 'args': job.args,
+          \ 'status': status,
+          \ 'content': pipe._stderr,
+          \})
+  endif
+  call gina#core#meta#set('chunks', job.chunks)
+  call gina#core#meta#set('revisions', job.revisions)
+  call s:redraw_content()
+  call gina#util#syncbind()
+  setlocal filetype=gina-blame
+endfunction
+
+function! s:VimResized() abort
+  call s:redraw_content()
+  call gina#util#syncbind()
+endfunction
+
+function! s:redraw_content() abort
+  let args = gina#core#meta#get_or_fail('args')
+  let chunks = gina#core#meta#get_or_fail('chunks')
+  let revisions = gina#core#meta#get_or_fail('revisions')
+  let formatter = gina#command#blame#formatter#new(
+        \ winwidth(0),
+        \ args.params.rev,
+        \ revisions,
+        \)
+  if exists('b:gina_blame_writer')
+    call b:gina_blame_writer.kill()
+  endif
+  if len(chunks) < g:gina#command#blame#writer_threshold
+    let content = []
+    call map(copy(chunks), 'extend(content, formatter.format(v:val))')
+    call gina#core#writer#assign_content(v:null, content)
+  else
+    " To improve UX, use writer for chunks over 1000 (e.g. vim/src/eval.c)
+    let writer = gina#core#writer#new(s:writer)
+    let writer.formatter = formatter
+    call writer.start()
+    call map(copy(chunks), 'writer.write(v:val)')
+    call writer.stop()
+    let b:gina_blame_writer = writer
+  endif
+endfunction
+
+function! s:get_candidates(fline, lline) abort
+  let args = gina#core#meta#get_or_fail('args')
+  let chunks = gina#core#meta#get_or_fail('chunks')
+  let revisions = gina#core#meta#get_or_fail('revisions')
+  let fidx = s:binary_search(chunks, a:fline, 0, len(chunks) - 1)
+  let lidx = s:binary_search(chunks, a:lline, 0, len(chunks) - 1)
+  let candidates = map(
+        \ range(fidx, lidx),
+        \ 's:translate_candidate(args.params.rev, chunks[v:val], revisions)'
+        \)
+  return candidates
+endfunction
+
+function! s:binary_search(chunks, lnum, imin, imax) abort
+  if a:imax < a:imin
+    return v:null
+  endif
+  let imid = a:imin + (a:imax - a:imin) / 2
+  let chunk = a:chunks[imid]
+  if chunk.lnum > a:lnum
+    return s:binary_search(a:chunks, a:lnum, a:imin, imid - 1)
+  elseif (chunk.lnum + chunk.nlines - 1) < a:lnum
+    return s:binary_search(a:chunks, a:lnum, imid + 1, a:imax)
+  else
+    return imid
+  endif
+endfunction
+
+function! s:translate_candidate(rev, chunk, revisions) abort
+  let chunk = copy(a:chunk)
+  call extend(chunk, s:Dict.omit(a:revisions[chunk.revision], [
+        \ 'lnum_from', 'lnum', 'nlines',
+        \]))
+  if chunk.revision =~# '^' . a:rev && has_key(chunk, 'previous')
+    let rev = matchstr(chunk.previous, '^\S\+')
+    let path = matchstr(chunk.previous, '^\S\+ \zs.*')
+    let line = v:null
+  else
+    let rev = chunk.revision
+    let path = chunk.filename
+    let line = chunk.lnum_from
+  endif
+  return extend(chunk, {
+        \ 'rev': rev,
+        \ 'path': path,
+        \ 'line': line,
+        \})
+endfunction
+
+
+" Writer ---------------------------------------------------------------------
+let s:writer = {}
+
+function! s:writer.on_read(msg) abort
+  if a:msg is# v:null
+    retur a:msg
+  endif
+  let leading = a:msg.index == 0 ? [] : ['']
+  return leading + self.formatter.format(a:msg)
+endfunction
+
+
+" Config ---------------------------------------------------------------------
+call gina#config(expand('<sfile>'), {
+      \ 'use_default_aliases': 1,
+      \ 'use_default_mappings': 1,
+      \ 'writer_threshold': 1000,
+      \})

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -14,6 +14,20 @@ function! gina#command#blame#call(range, args, mods) abort
   endtry
 endfunction
 
+function! gina#command#blame#echo(chunk) abort
+  let timestamp = gina#command#blame#timestamper#new().format(
+        \ a:chunk.author_time,
+        \ a:chunk.author_tz,
+        \)
+  redraw | call gina#core#console#info(printf(
+        \ '%s: %s authored on %s [%s]',
+        \ a:chunk.summary,
+        \ a:chunk.author,
+        \ timestamp,
+        \ a:chunk.revision,
+        \))
+endfunction
+
 
 " Private --------------------------------------------------------------------
 function! s:build_args(git, args) abort
@@ -25,7 +39,7 @@ function! s:build_args(git, args) abort
   let args.params.opener = args.pop('--opener', 'edit')
   let args.params.line = args.pop('--line', v:null)
   let args.params.col = args.pop('--col', v:null)
-  let args.params.width = args.pop('--width', 30)
+  let args.params.width = args.pop('--width', 35)
 
   call gina#core#args#extend_treeish(a:git, args, args.pop(1))
   if empty(args.params.path)
@@ -125,11 +139,6 @@ function! s:init(args) abort
   call gina#action#include('compare')
   call gina#action#include('diff')
   call gina#action#include('show')
-
-  augroup gina_command_blame_internal
-    autocmd! * <buffer>
-    autocmd BufReadCmd <buffer> call s:BufReadCmd()
-    autocmd VimResized <buffer> call s:VimResized()
 
   augroup gina_command_blame_internal
     autocmd! * <buffer>

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -69,7 +69,7 @@ function! s:call(range, args, mods) abort
   call s:open(mods, args.params.opener, args.params)
   call group.add()
   windo setlocal noscrollbind
-  setlocal scrollbind nowrap
+  setlocal scrollbind nowrap nofoldenable
   augroup gina_command_blame_internal
     autocmd! * <buffer>
     autocmd WinLeave <buffer> call s:WinLeave()

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -212,9 +212,12 @@ function! s:redraw_content() abort
     call b:gina_blame_writer.kill()
   endif
   if len(chunks) < g:gina#command#blame#writer_threshold
+    let winview_saved = winsaveview()
     let content = []
     call map(copy(chunks), 'extend(content, formatter.format(v:val))')
     call gina#core#writer#assign_content(v:null, content)
+    call winrestview(winview_saved)
+    call gina#util#syncbind()
   else
     " To improve UX, use writer for chunks over 1000 (e.g. vim/src/eval.c)
     let writer = gina#core#writer#new(s:writer)
@@ -230,7 +233,6 @@ endfunction
 function! s:redraw_content_if_necessary() abort
   if exists('b:gina_previous_winwidth') && b:gina_previous_winwidth != winwidth(0)
     call s:redraw_content()
-    call gina#util#syncbind()
   endif
 endfunction
 

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -267,15 +267,9 @@ function! s:translate_candidate(rev, chunk, revisions) abort
   call extend(chunk, s:Dict.omit(a:revisions[chunk.revision], [
         \ 'lnum_from', 'lnum', 'nlines',
         \]))
-  if chunk.revision =~# '^' . a:rev && has_key(chunk, 'previous')
-    let rev = matchstr(chunk.previous, '^\S\+')
-    let path = matchstr(chunk.previous, '^\S\+ \zs.*')
-    let line = v:null
-  else
-    let rev = chunk.revision
-    let path = chunk.filename
-    let line = chunk.lnum_from
-  endif
+  let rev = chunk.revision
+  let path = chunk.filename
+  let line = chunk.lnum_from
   return extend(chunk, {
         \ 'rev': rev,
         \ 'path': path,

--- a/autoload/gina/command/blame/formatter.vim
+++ b/autoload/gina/command/blame/formatter.vim
@@ -1,0 +1,131 @@
+scriptencoding utf-8
+let s:String = vital#gina#import('Data.String')
+
+
+function! gina#command#blame#formatter#new(width, current, revisions) abort
+  let formatter = deepcopy(s:formatter)
+  let formatter.width = a:width
+  let formatter.current = a:current
+  let formatter.revisions = a:revisions
+  let formatter.timestamper = gina#command#blame#timestamper#new()
+  let formatter._previous = 1
+  let formatter._cache1 = {}
+  let formatter._cache2 = {}
+  let formatter._cache3 = {}
+  let formatter._cache4 = {}
+  return formatter
+endfunction
+
+
+" Formatter ------------------------------------------------------------------
+let s:formatter = {}
+
+function! s:formatter.format(chunk) abort
+  let revision = a:chunk.revision
+  let revinfo = self.revisions[revision]
+  let nlines = a:chunk.nlines > 3 ? 4 : a:chunk.nlines
+  if a:chunk.nlines == 1
+    let content = self._format1(a:chunk, revision, revinfo)
+  elseif a:chunk.nlines == 2
+    let content = self._format2(a:chunk, revision, revinfo)
+  elseif a:chunk.nlines == 3
+    let content = self._format3(a:chunk, revision, revinfo)
+  else
+    let content = self._format4(a:chunk, revision, revinfo)
+  endif
+  " Fill missing lines from previous
+  let mlines = a:chunk.lnum - self._previous
+  let self._previous = a:chunk.lnum + a:chunk.nlines
+  return repeat([''], mlines) + content
+endfunction
+
+" 03gft2g    @lambdalisue
+function! s:formatter._format1(chunk, revision, revinfo) abort
+  if has_key(self._cache1, a:revision)
+    return self._cache1[a:revision]
+  endif
+  let length = self.width - 8
+  let author = s:String.trim(s:String.truncate_skipping(
+        \ '@' . a:revinfo.author,
+        \ length - 1, 2,
+        \ g:gina#command#blame#formatter#separator,
+        \))
+  if get(a:revinfo, 'boundary')
+    let revision = '^' . a:revision[:6]
+  elseif !empty(self.current)
+        \ && a:revision =~# '^' . self.current
+    if has_key(a:revinfo, 'previous')
+      let revision = a:revision[:6] . '^'
+    else
+      let revision = '$' . a:revision[:6]
+    endif
+  else
+    let revision = a:revision[:7]
+  endif
+  let content = [revision . s:String.pad_left(author, length)]
+  let self._cache1[a:revision] = content
+  retur content
+endfunction
+
+" 03gft2g    @lambdalisue
+" Summary of the commit m
+function! s:formatter._format2(chunk, revision, revinfo) abort
+  if has_key(self._cache2, a:revision)
+    return self._cache2[a:revision]
+  endif
+  let summary = s:String.truncate_skipping(
+        \ a:revinfo.summary,
+        \ self.width, 2,
+        \ g:gina#command#blame#formatter#separator,
+        \)
+  let content = copy(self._format1(a:chunk, a:revision, a:revinfo))
+  let content += [s:String.pad_right(summary, self.width)]
+  let self._cache2[a:revision] = content
+  return content
+endfunction
+
+" 03gft2g    @lambdalisue
+" Summary of the commit m
+" |            2 days ago
+function! s:formatter._format3(chunk, revision, revinfo) abort
+  if has_key(self._cache3, a:revision)
+    return self._cache3[a:revision]
+  endif
+  let timestamp = self.timestamper.format(
+        \ a:revinfo.author_time,
+        \ a:revinfo.author_tz
+        \)
+  let content = copy(self._format2(a:chunk, a:revision, a:revinfo))
+  let content += ['|' . s:String.pad_left(timestamp, self.width - 1)]
+  let self._cache3[a:revision] = content
+  return content
+endfunction
+
+" 03gft2g    @lambdalisue
+" Summary of the commit m
+" essage
+" |
+" |            2 days ago
+function! s:formatter._format4(chunk, revision, revinfo) abort
+  if has_key(self._cache4, a:revision)
+    let summary = self._cache4[a:revision]
+  else
+    let summary = map(
+          \ s:String.wrap(a:revinfo.summary, self.width),
+          \ 's:String.pad_right(s:String.trim(v:val), self.width)',
+          \)
+    let self._cache4[a:revision] = summary
+  endif
+  let nlines = a:chunk.nlines - 2
+  let content = copy(self._format3(a:chunk, a:revision, a:revinfo))
+  call remove(content, 1)
+  call extend(content, summary[:nlines-1], 1)
+  call extend(content, repeat(['|'], nlines - len(content)), -1)
+  return content
+endfunction
+
+
+" Config ---------------------------------------------------------------------
+call gina#config(expand('<sfile>'), {
+      \ 'separator': '⋯',
+      \})

--- a/autoload/gina/command/blame/formatter.vim
+++ b/autoload/gina/command/blame/formatter.vim
@@ -1,19 +1,42 @@
 scriptencoding utf-8
 let s:String = vital#gina#import('Data.String')
 
+let s:CURRENT_MARK = '▌'
+let s:N_COLORS = 16
+
 
 function! gina#command#blame#formatter#new(width, current, revisions) abort
   let formatter = deepcopy(s:formatter)
-  let formatter.width = a:width
-  let formatter.current = a:current
-  let formatter.revisions = a:revisions
-  let formatter.timestamper = gina#command#blame#timestamper#new()
+  let formatter._width = a:width
+  let formatter._current = empty(a:current) ? 'X' : a:current
+  let formatter._revisions = s:index_revisions(a:revisions)
   let formatter._previous = 1
-  let formatter._cache1 = {}
-  let formatter._cache2 = {}
-  let formatter._cache3 = {}
-  let formatter._cache4 = {}
+  let formatter._timestamper = gina#command#blame#timestamper#new()
+  let formatter._cache = {}
   return formatter
+endfunction
+
+
+" Private --------------------------------------------------------------------
+function! s:index_revisions(revisions) abort
+  let n = s:calc_nindicators(a:revisions)
+  let revisions = deepcopy(a:revisions)
+  let keys = keys(revisions)
+  for index in range(len(revisions))
+    let revisions[keys[index]].index = s:String.pad_left(
+          \ s:String.nr2hex(index), n, '0'
+          \)
+  endfor
+  return revisions
+endfunction
+
+function! s:calc_nindicators(revisions) abort
+  let n = len(a:revisions)
+  let x = 1
+  while pow(s:N_COLORS, x) < n
+    let x+= 1
+  endwhile
+  return x
 endfunction
 
 
@@ -22,106 +45,35 @@ let s:formatter = {}
 
 function! s:formatter.format(chunk) abort
   let revision = a:chunk.revision
-  let revinfo = self.revisions[revision]
-  let nlines = a:chunk.nlines > 3 ? 4 : a:chunk.nlines
-  if a:chunk.nlines == 1
-    let content = self._format1(a:chunk, revision, revinfo)
-  elseif a:chunk.nlines == 2
-    let content = self._format2(a:chunk, revision, revinfo)
-  elseif a:chunk.nlines == 3
-    let content = self._format3(a:chunk, revision, revinfo)
-  else
-    let content = self._format4(a:chunk, revision, revinfo)
-  endif
+  let revinfo = self._revisions[revision]
+  let content = repeat(
+        \ [self._format_line(a:chunk, revision, revinfo)],
+        \ a:chunk.nlines,
+        \)
   " Fill missing lines from previous
   let mlines = a:chunk.lnum - self._previous
   let self._previous = a:chunk.lnum + a:chunk.nlines
   return repeat([''], mlines) + content
 endfunction
 
-" 03gft2g    @lambdalisue
-function! s:formatter._format1(chunk, revision, revinfo) abort
-  if has_key(self._cache1, a:revision)
-    return self._cache1[a:revision]
+function! s:formatter._format_line(chunk, revision, revinfo) abort
+  if has_key(self._cache, a:revision)
+    return self._cache[a:revision]
   endif
-  let length = self.width - 8
-  let author = s:String.trim(s:String.truncate_skipping(
-        \ '@' . a:revinfo.author,
-        \ length - 1, 2,
-        \ g:gina#command#blame#formatter#separator,
-        \))
-  if get(a:revinfo, 'boundary')
-    let revision = '^' . a:revision[:6]
-  elseif !empty(self.current)
-        \ && a:revision =~# '^' . self.current
-    if has_key(a:revinfo, 'previous')
-      let revision = a:revision[:6] . '^'
-    else
-      let revision = '$' . a:revision[:6]
-    endif
-  else
-    let revision = a:revision[:7]
-  endif
-  let content = [revision . s:String.pad_left(author, length)]
-  let self._cache1[a:revision] = content
-  retur content
-endfunction
-
-" 03gft2g    @lambdalisue
-" Summary of the commit m
-function! s:formatter._format2(chunk, revision, revinfo) abort
-  if has_key(self._cache2, a:revision)
-    return self._cache2[a:revision]
-  endif
-  let summary = s:String.truncate_skipping(
-        \ a:revinfo.summary,
-        \ self.width, 2,
-        \ g:gina#command#blame#formatter#separator,
-        \)
-  let content = copy(self._format1(a:chunk, a:revision, a:revinfo))
-  let content += [s:String.pad_right(summary, self.width)]
-  let self._cache2[a:revision] = content
-  return content
-endfunction
-
-" 03gft2g    @lambdalisue
-" Summary of the commit m
-" |            2 days ago
-function! s:formatter._format3(chunk, revision, revinfo) abort
-  if has_key(self._cache3, a:revision)
-    return self._cache3[a:revision]
-  endif
-  let timestamp = self.timestamper.format(
+  let mark = a:revision =~# '^' . self._current ? s:CURRENT_MARK : ' '
+  let timestamp = 'on ' . self._timestamper.format(
         \ a:revinfo.author_time,
         \ a:revinfo.author_tz
         \)
-  let content = copy(self._format2(a:chunk, a:revision, a:revinfo))
-  let content += ['|' . s:String.pad_left(timestamp, self.width - 1)]
-  let self._cache3[a:revision] = content
-  return content
-endfunction
-
-" 03gft2g    @lambdalisue
-" Summary of the commit m
-" essage
-" |
-" |            2 days ago
-function! s:formatter._format4(chunk, revision, revinfo) abort
-  if has_key(self._cache4, a:revision)
-    let summary = self._cache4[a:revision]
-  else
-    let summary = map(
-          \ s:String.wrap(a:revinfo.summary, self.width),
-          \ 's:String.pad_right(s:String.trim(v:val), self.width)',
-          \)
-    let self._cache4[a:revision] = summary
-  endif
-  let nlines = a:chunk.nlines - 2
-  let content = copy(self._format3(a:chunk, a:revision, a:revinfo))
-  call remove(content, 1)
-  call extend(content, summary[:nlines-1], 1)
-  call extend(content, repeat(['|'], nlines - len(content)), -1)
-  return content
+  let suffix = join([timestamp, mark . a:revinfo.index])
+  let width = self._width - strwidth(suffix) - 1
+  let summary = s:String.truncate_skipping(
+        \ a:revinfo.summary, width, 3,
+        \ g:gina#command#blame#formatter#separator,
+        \)
+  let summary = s:String.pad_right(summary, width)
+  let self._cache[a:revision] = join([summary, suffix])
+  return self._cache[a:revision]
 endfunction
 
 

--- a/autoload/gina/command/blame/formatter.vim
+++ b/autoload/gina/command/blame/formatter.vim
@@ -1,7 +1,5 @@
-scriptencoding utf-8
 let s:String = vital#gina#import('Data.String')
 
-let s:CURRENT_MARK = '▌'
 let s:N_COLORS = 16
 
 
@@ -60,7 +58,9 @@ function! s:formatter._format_line(chunk, revision, revinfo) abort
   if has_key(self._cache, a:revision)
     return self._cache[a:revision]
   endif
-  let mark = a:revision =~# '^' . self._current ? s:CURRENT_MARK : ' '
+  let mark = a:revision =~# '^' . self._current
+        \ ? g:gina#command#blame#formatter#current_mark
+        \ : repeat(' ', len(g:gina#command#blame#formatter#current_mark))
   let timestamp = 'on ' . self._timestamper.format(
         \ a:revinfo.author_time,
         \ a:revinfo.author_tz
@@ -79,5 +79,6 @@ endfunction
 
 " Config ---------------------------------------------------------------------
 call gina#config(expand('<sfile>'), {
-      \ 'separator': '⋯',
+      \ 'separator': '...',
+      \ 'current_mark': '|',
       \})

--- a/autoload/gina/command/blame/pipe.vim
+++ b/autoload/gina/command/blame/pipe.vim
@@ -1,0 +1,102 @@
+let s:KEYWORDS = [
+      \ 'author-mail',
+      \ 'author-time',
+      \ 'author-tz',
+      \ 'author',
+      \ 'committer-mail',
+      \ 'committer-time',
+      \ 'committer-tz',
+      \ 'committer',
+      \ 'summary',
+      \ 'previous',
+      \ 'filename',
+      \ 'boundary',
+      \]
+call map(
+      \ s:KEYWORDS,
+      \ '[v:val, len(v:val), substitute(v:val, ''-'', ''_'', ''g'')]',
+      \)
+
+function! gina#command#blame#pipe#incremental() abort
+  let parser_pipe = deepcopy(s:parser_pipe)
+  let parser_pipe.revisions = {}
+  let parser_pipe.chunks = []
+  let parser_pipe._stderr = []
+  let parser_pipe._chunk = {}
+  let parser_pipe._previous = ''
+  return parser_pipe
+endfunction
+
+
+" Parser pipe ----------------------------------------------------------------
+let s:parser_pipe = gina#util#inherit(gina#process#pipe#echo())
+
+function! s:parser_pipe.on_stdout(job, msg, event) abort
+  if len(a:msg) <= 1
+    let self._previous .= get(a:msg, 0, '')
+    return
+  endif
+  let content = [self._previous . a:msg[0]] + a:msg[1:-2]
+  let self._previous = a:msg[-1]
+  call map(content, 'self.parse(v:val)')
+endfunction
+
+function! s:parser_pipe.on_exit(job, msg, event) abort
+  if a:msg == 0
+    if !empty(self._previous)
+      call self.parse(self._previous)
+    endif
+    call sort(self.chunks, function('s:compare_chunks'))
+    call map(self.chunks, 'extend(v:val, {''index'': v:key})')
+  endif
+  call self.super(s:parser_pipe, 'on_exit', a:job, a:msg, a:event)
+endfunction
+
+function! s:parser_pipe.parse(record) abort
+  let chunk = self._chunk
+  let revisions = self.revisions
+  call extend(chunk, s:parse_record(a:record))
+  if !has_key(chunk, 'filename')
+    return
+  endif
+  if !has_key(revisions, chunk.revision)
+    let revisions[chunk.revision] = chunk
+    let chunk = {
+          \ 'filename': chunk.filename,
+          \ 'revision': chunk.revision,
+          \ 'lnum_from': chunk.lnum_from,
+          \ 'lnum': chunk.lnum,
+          \ 'nlines': chunk.nlines,
+          \}
+  endif
+  call add(self.chunks, chunk)
+  let self._chunk = {}
+endfunction
+
+
+" Private --------------------------------------------------------
+function! s:parse_record(record) abort
+  for [prefix, length, vname] in s:KEYWORDS
+    if a:record[:length-1] ==# prefix
+      return {vname : a:record[length+1:]}
+    endif
+  endfor
+  let terms = split(a:record)
+  let nterms = len(terms)
+  if nterms >= 3
+    return {
+          \ 'revision': terms[0],
+          \ 'lnum_from': terms[1] + 0,
+          \ 'lnum': terms[2] + 0,
+          \ 'nlines': nterms == 3 ? 1 : (terms[3] + 0),
+          \}
+  endif
+  throw gina#core#exception#critical(printf(
+        \ 'Failed to parse a record "%s"',
+        \ a:record,
+        \))
+endfunction
+
+function! s:compare_chunks(lhs, rhs) abort
+  return a:lhs.lnum - a:rhs.lnum
+endfunction

--- a/autoload/gina/command/blame/timestamper.vim
+++ b/autoload/gina/command/blame/timestamper.vim
@@ -1,0 +1,69 @@
+let s:DateTime = vital#gina#import('DateTime')
+
+
+function! gina#command#blame#timestamper#new(...) abort
+  let timestamper = deepcopy(s:timestamper)
+  let timestamper._now = a:0 == 0 ? s:DateTime.now() : a:1
+  let timestamper._cache_timezone = {}
+  let timestamper._cache_datetime = {}
+  let timestamper._cache_timestamp = {}
+  return timestamper
+endfunction
+
+function! gina#command#blame#timestamper#format(epoch, timezone) abort
+  let timestamper = gina#command#blame#timestamper#new()
+  return timestamper.format(a:epoch, a:timezone)
+endfunction
+
+
+" Timestamper ----------------------------------------------------------------
+let s:timestamper = {}
+
+function! s:timestamper._timezone(timezone) abort
+  if has_key(self._cache_timezone, a:timezone)
+    return self._cache_timezone[a:timezone]
+  endif
+  let timezone = s:DateTime.timezone(a:timezone)
+  let self._cache_timezone[a:timezone] = timezone
+  return timezone
+endfunction
+
+function! s:timestamper._datetime(epoch, timezone) abort
+  let cname = a:epoch . a:timezone
+  if has_key(self._cache_datetime, cname)
+    return self._cache_datetime[cname]
+  endif
+  let timezone = self._timezone(a:timezone)
+  let datetime = s:DateTime.from_unix_time(a:epoch, timezone)
+  let self._cache_datetime[cname] = datetime
+  return datetime
+endfunction
+
+function! s:timestamper.format(epoch, timezone) abort
+  let cname = a:epoch . a:timezone
+  if has_key(self._cache_timestamp, cname)
+    return self._cache_timestamp[cname]
+  endif
+  let datetime = self._datetime(a:epoch, a:timezone)
+  let timedelta = datetime.delta(self._now)
+  if timedelta.duration().months() < 3
+    let timestamp = timedelta.about()
+  elseif datetime.year() == self._now.year()
+    let timestamp = 'on ' . datetime.strftime(
+          \ g:gina#command#blame#timestamper#format1
+          \)
+  else
+    let timestamp = 'on ' . datetime.strftime(
+          \ g:gina#command#blame#timestamper#format2
+          \)
+  endif
+  let self._cache_timestamp[cname] = timestamp
+  return timestamp
+endfunction
+
+
+" Config ---------------------------------------------------------------------
+call gina#config(expand('<sfile>'), {
+      \ 'format1': '%d %b',
+      \ 'format2': '%d %b, %Y',
+      \})

--- a/autoload/gina/command/blame/timestamper.vim
+++ b/autoload/gina/command/blame/timestamper.vim
@@ -49,11 +49,11 @@ function! s:timestamper.format(epoch, timezone) abort
   if timedelta.duration().months() < 3
     let timestamp = timedelta.about()
   elseif datetime.year() == self._now.year()
-    let timestamp = 'on ' . datetime.strftime(
+    let timestamp = datetime.strftime(
           \ g:gina#command#blame#timestamper#format1
           \)
   else
-    let timestamp = 'on ' . datetime.strftime(
+    let timestamp = datetime.strftime(
           \ g:gina#command#blame#timestamper#format2
           \)
   endif

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -21,6 +21,7 @@ CUSTOM				|gina-custom|
   EXECUTE			  |gina-custom-execute|
   EXAMPLE			  |gina-custom-example|
 BUFFER				|gina-buffer|
+  BLAME				  |gina-buffer-blame|
   BRANCH			  |gina-buffer-branch|
   CHANGES			  |gina-buffer-changes|
   COMMIT			  |gina-buffer-commit|
@@ -629,6 +630,102 @@ Note that automatical detection by 'fileencodings' or 'fileformats' are not
 supported. Upvote https://github.com/lambdalisue/gina.vim/issues/24 if need.
 
 -----------------------------------------------------------------------------
+BLAME						*gina-buffer-blame*
+					{scheme}:	blame
+					'filetype':	gina-blame
+
+This is a "non file-like" buffer which is shown by |:Gina-blame| command.
+It shows a content of the file with a blame navigator looks like (note that
+SHA1 indicators are represented as a shade block but it is colored columns in
+real world)
+>
+	Navigation buffer                 Content buffer
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~
+	Add badges o... on yesterday  ░ | ![...](...)
+	Add badges o... on yesterday  ░ | ![...](...)
+	...
+	Initial commit    on 14, Feb    | FOOBAR HOGEHOGE
+	Some refactoring    on today |█ | ![...](...)
+
+               │              │      ││
+               │              │      │└ SHA1 indicator column(s) (N chars)
+               │              │      └ Current revision mark
+               │              └ Timestamp (relative or absolute)
+               └ Commit summary
+<
+Continuous lines with a same revision (commit) is called a "chunk". Not like
+a git raw blame command, gina does not show a revision of each chunks/lines.
+Instead, gina uses SHA1 indicator column(s) to distinguish revisions.
+
+SHA1 indicator column(s) is a colored column or combinations of colored
+columns which indicate an unique revision in a blame content. The number of
+columns used to indicate a single revision is determined from the total
+numbers of revisions shown in a blame content. Namely, same colored column or
+same colored columns combination indicate a same revision so that users can
+easily distinguish which lines are continuous or which chunks are equal.
+
+When a revision of a chunk is equal to a revision of a blame content, a
+current revision mark (default is "|") is shown just next to the SHA1
+indicator. In this case, "blame:open" action would open a related parent
+commit if exists rather than the commit itself.
+
+The navigation content is width dependent. When the window width of the 
+"gina-blame" buffer has changed, the content will be redrawn when
+	
+	- Users hit <C-L> (<Plug>(gina-blame-C-L))
+	- Focus is moved from/to the buffer (|WinLeave| or |WinEnter|)
+	- Vim's window is resized (|VimResized|)
+
+In this buffer, users can use the following action groups.
+
+	|gina-action-blame|	(shorten)
+	|gina-action-browse| 
+	|gina-action-changes|
+	|gina-action-compare|
+	|gina-action-diff|
+	|gina-action-show|
+
+And the following <Plug> mappings
+	
+	<Plug>(gina-blame-redraw)	Redraw content with the current width
+	<Plug>(gina-blame-C-L)		Redraw content and <C-L> to refresh
+
+And the following default keymappings
+	
+	<Return>	Open a blame with the selected chunk
+	<Backspace>	Back to navigationally historical previous blame
+	<C-L>		Redraw content and <C-L> to refresh
+
+Users can disable the default aliases (shorten) and/or mappings by
+
+	|g:gina#command#blame#use_default_aliases|
+	|g:gina#command#blame#use_default_mappings|
+
+Set 0 to these value disable default settings.
+
+Additionally, users can customize the content via the following variables.
+
+	|g:gina#command#blame#formatter#separator|
+	|g:gina#command#blame#formatter#current_mark|
+	|g:gina#command#blame#timestamper#format1|
+	|g:gina#command#blame#timestamper#format2|
+>
+The following is a recommended customization while gina does not show exact
+SHA1 of the revision of the chunk.
+>
+	" Echo chunk info with j/k
+	call gina#custom#mapping#nmap(
+	      \ 'blame', 'j',
+	      \ 'j<Plug>(gina-blame-echo)'
+	      \)
+	call gina#custom#mapping#nmap(
+	      \ 'blame', 'k',
+	      \ 'k<Plug>(gina-blame-echo)'
+	      \)
+<
+The above may influence the performance so it is not defined in default.
+
+-----------------------------------------------------------------------------
 BRANCH						*gina-buffer-branch*
 					{scheme}:	branch
 					'filetype':	gina-branch
@@ -942,6 +1039,34 @@ Additionally [+cmd] and [++opt] are supported. See |gina-buffer-+cmd| and
 	Otherwise it calls a raw {command} ("git {command} {options}") and
 	echo the result.
 	Users can force to call a raw cammand by a |bang| modifier.
+
+						*:Gina-blame*
+:Gina blame [+cmd] [++opt] [{options}] {treeish}
+	Open a "gina-blame" buffer to blame changes of the content.
+	If {treeish} is missing, {rev} part of the {treeish} is guessed from a
+	current buffer and {path} part will be omitted. Use ":" instead if you
+	would like to guess {path} part as well (|gina-misc-treeish|).
+	If {path} part of the {treeish} is omitted, it warn and fail.
+
+	The followings are allowed in {options}
+
+	--group1={group}
+		A window group name used for the navigation buffer
+		(|gina-options-group|)
+	--group2={group}
+		A window group name used for the content buffer
+		(|gina-options-group|)
+	--opener={opener}
+		An opener command for the 1st buffer (|gina-options-opener|)
+	--line={line}
+		An initial line number
+	--col={col}
+		An initial column number
+	--width={width}
+		Width used for the navigation buffer
+
+	See also~
+	|gina-buffer-blame|
 
 						*:Gina-branch*
 :Gina branch [+cmd] [++opt] [{options}]
@@ -1419,6 +1544,7 @@ g:gina#action#mark_sign_text
 	See |gina-usage-action-mark| for what the mark is.
 	Default: "|"
 
+		*g:gina#command#blame#use_default_aliases*
 		*g:gina#command#branch#use_default_aliases*
 		*g:gina#command#changes#use_default_aliases*
 		*g:gina#command#grep#use_default_aliases*
@@ -1432,6 +1558,7 @@ g:gina#command#{scheme}#use_default_aliases
 	Assign 0 if you would like to disable the default action aliases.
 	Default: 1
 
+		*g:gina#command#blame#use_default_mappings*
 		*g:gina#command#branch#use_default_mappings*
 		*g:gina#command#changes#use_default_mappings*
 		*g:gina#command#chaperon#use_default_mappings*
@@ -1448,10 +1575,28 @@ g:gina#command#{scheme}#use_default_mappings
 	Assign 0 if you would like to disable the default mappings.
 	Default: 1
 
-		*g:gina#command#grep#send_to_quickfix*
-g:gina#command#grep#send_to_quickfix
-	Send all candidates to quickfix after command execution.
-	Default: 1
+		*g:gina#command#blame#formatter#separator*
+g:gina#command#blame#formatter#separator
+	A separator text used to indicate that the content is squashed.
+	Default: "..."
+
+		*g:gina#command#blame#formatter#current_mark*
+g:gina#command#blame#formatter#current_mark 
+	A current mark text used to indicate that the revision of the chunk is
+	equal to the revision of the blame content.
+	Default: "|"
+
+		*g:gina#command#blame#timestamper#format1*
+g:gina#command#blame#timestamper#format1
+	A |strftime()| format used for an absolute timestamp which year is
+	equal to the year of the current time.
+	Default: "%d %b"
+
+		*g:gina#command#blame#timestamper#format2*
+g:gina#command#blame#timestamper#format2
+	A |strftime()| format used for an absolute timestamp which year is
+	NOT equal to the year of the current time.
+	Default: "%d %b, %Y"
 
 		*g:gina#command#browse#translation_patterns*
 g:gina#command#browse#translation_patterns
@@ -1511,6 +1656,11 @@ g:gina#command#browse#translation_patterns
 	    \ ],
 	    \})
 <
+		*g:gina#command#grep#send_to_quickfix*
+g:gina#command#grep#send_to_quickfix
+	Send all candidates to quickfix after command execution.
+	Default: 1
+
 		*g:gina#process#command*
 g:gina#process#command
 	A command string used to execute a git process.
@@ -1617,6 +1767,20 @@ builtin:repeat (hidden)
 	Repeat a previous repeatable action which was executed from
 	"builtin:choice" action.
 	The action is mapped to "." in normal, visual, and insert mode.
+
+					*gina-actions-blame*
+blame:echo
+	Echo the chunk info. It is only available on a "gina-blame" buffer.
+	The following customization is recommended if your PC is fast enough.
+blame:open
+	Open a blame with the selected candidate.
+	It opens a blame with a related parent (previous) commit if the
+	revision of the chunk and the revision of the blame is equal and a
+	related parent commit exist.
+	Note that this action is recorded in an internal blame history used
+	for "blame:back" action.
+blame:back
+	Back to a navigational previous blame recorded by "blame:open" action.
 
 					*gina-actions-branch*
 branch:checkout

--- a/ftplugin/gina-blame.vim
+++ b/ftplugin/gina-blame.vim
@@ -12,10 +12,8 @@ setlocal foldcolumn=0 colorcolumn=0
 if g:gina#command#blame#use_default_aliases
   call gina#action#shorten('blame')
 endif
-"
+
 if g:gina#command#blame#use_default_mappings
   nmap <buffer> <Return>    <Plug>(gina-blame-open)
   nmap <buffer> <Backspace> <Plug>(gina-blame-back)
-  nmap <buffer> j           j<Plug>(gina-blame-echo)
-  nmap <buffer> k           k<Plug>(gina-blame-echo)
 endif

--- a/ftplugin/gina-blame.vim
+++ b/ftplugin/gina-blame.vim
@@ -16,4 +16,5 @@ endif
 if g:gina#command#blame#use_default_mappings
   nmap <buffer> <Return>    <Plug>(gina-blame-open)
   nmap <buffer> <Backspace> <Plug>(gina-blame-back)
+  nmap <buffer> <C-L>       <Plug>(gina-blame-C-L)
 endif

--- a/ftplugin/gina-blame.vim
+++ b/ftplugin/gina-blame.vim
@@ -1,0 +1,21 @@
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal nobuflisted
+setlocal nolist nospell
+setlocal nowrap nofoldenable
+setlocal nonumber norelativenumber
+setlocal foldcolumn=0 colorcolumn=0
+
+if g:gina#command#blame#use_default_aliases
+  call gina#action#shorten('blame')
+endif
+"
+if g:gina#command#blame#use_default_mappings
+  nmap <buffer> <Return>    <Plug>(gina-blame-open)
+  nmap <buffer> <Backspace> <Plug>(gina-blame-back)
+  nmap <buffer> j           j<Plug>(gina-blame-echo)
+  nmap <buffer> k           k<Plug>(gina-blame-echo)
+endif

--- a/syntax/gina-blame.vim
+++ b/syntax/gina-blame.vim
@@ -1,21 +1,55 @@
+scriptencoding utf-8
+
 if exists('b:current_syntax')
   finish
 endif
-syntax match GinaBlameAdditional /^|.*/
-syntax match GinaBlameHead /^\%(\w\{8}\|\w\{7}\^\|\^\w\{7}\|\$\w\{7}\)\s\+@.*$/
-syntax match GinaBlameAuthor /@.*$/ containedin=GinaBlameHead
-syntax match GinaBlameRevNormal /^\w\{8}/ containedin=GinaBlameHead
-syntax match GinaBlameRevParent /^\w\{7}\^/ containedin=GinaBlameHead
-syntax match GinaBlameRevBoundary /^\^\w\{7}/ containedin=GinaBlameHead
-syntax match GinaBlameRevTerminal /^\$\w\{7}/ containedin=GinaBlameHead
+
+" Ref: https://github.com/w0ng/vim-hybrid
+let s:GUI_COLORS = [
+      \ '#282A2E', '#A54242', '#8C9440', '#DE935F',
+      \ '#5F819D', '#85678F', '#5E8D87', '#707880',
+      \ '#373B41', '#CC6666', '#B5BD68', '#F0C674',
+      \ '#81A2BE', '#B294BB', '#8ABEB7', '#C5C8C6',
+      \]
+let s:TERM_COLORS = [
+      \ 0, 1, 2, 3, 4, 5, 6, 7,
+      \ 8, 9, 10, 11, 12, 13, 14, 15,
+      \]
+
+syntax match GinaBlameBase /.*/ display
+syntax match GinaBlameSummary /^.*\zeon .\{-}/ containedin=GinaBlameBase
+
+syntax match GinaBlameRev /[ ▌][0-9A-F]\+$/ containedin=GinaBlameBase
+syntax match GinaBlameRevColor0  /0/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor1  /1/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor2  /2/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor3  /3/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor4  /4/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor5  /5/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor6  /6/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor7  /7/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor8  /8/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor9  /9/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor10 /A/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor11 /B/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor12 /C/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor13 /D/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor14 /E/ contained containedin=GinaBlameRev
+syntax match GinaBlameRevColor15 /F/ contained containedin=GinaBlameRev
+syntax match GinaBlameIndicator  /▌/ contained containedin=GinaBlameRev
 
 function! s:define_highlights() abort
-  highlight default link GinaBlameAdditional Comment
-  highlight default link GinaBlameAuthor Statement
-  highlight default link GinaBlameRevNormal Tag
-  highlight default link GinaBlameRevParent Type
-  highlight default link GinaBlameRevBoundary Constant
-  highlight default link GinaBlameRevTerminal Constant
+  highlight default link GinaBlameBase Comment
+  highlight default link GinaBlameSummary Statement
+  highlight default link GinaBlameIndicator ErrorMsg
+  for i in range(16)
+    execute printf(
+          \ 'highlight default %s ctermfg=%d ctermbg=%d guifg=%s guibg=%s',
+          \ 'GinaBlameRevColor' . i,
+          \ s:TERM_COLORS[i], s:TERM_COLORS[i],
+          \ s:GUI_COLORS[i], s:GUI_COLORS[i],
+          \)
+  endfor
 endfunction
 
 augroup gina_syntax_blame_internal

--- a/syntax/gina-blame.vim
+++ b/syntax/gina-blame.vim
@@ -1,0 +1,27 @@
+if exists('b:current_syntax')
+  finish
+endif
+syntax match GinaBlameAdditional /^|.*/
+syntax match GinaBlameHead /^\%(\w\{8}\|\w\{7}\^\|\^\w\{7}\|\$\w\{7}\)\s\+@.*$/
+syntax match GinaBlameAuthor /@.*$/ containedin=GinaBlameHead
+syntax match GinaBlameRevNormal /^\w\{8}/ containedin=GinaBlameHead
+syntax match GinaBlameRevParent /^\w\{7}\^/ containedin=GinaBlameHead
+syntax match GinaBlameRevBoundary /^\^\w\{7}/ containedin=GinaBlameHead
+syntax match GinaBlameRevTerminal /^\$\w\{7}/ containedin=GinaBlameHead
+
+function! s:define_highlights() abort
+  highlight default link GinaBlameAdditional Comment
+  highlight default link GinaBlameAuthor Statement
+  highlight default link GinaBlameRevNormal Tag
+  highlight default link GinaBlameRevParent Type
+  highlight default link GinaBlameRevBoundary Constant
+  highlight default link GinaBlameRevTerminal Constant
+endfunction
+
+augroup gina_syntax_blame_internal
+  autocmd! * <buffer>
+  autocmd ColorScheme * call s:define_highlights()
+augroup END
+
+call s:define_highlights()
+let b:current_syntax = 'gina-blame'

--- a/syntax/gina-blame.vim
+++ b/syntax/gina-blame.vim
@@ -19,7 +19,15 @@ let s:TERM_COLORS = [
 syntax match GinaBlameBase /.*/ display
 syntax match GinaBlameSummary /^.*\zeon .\{-}/ containedin=GinaBlameBase
 
-syntax match GinaBlameRev /[ ▌][0-9A-F]\+$/ containedin=GinaBlameBase
+execute printf(
+      \ 'syn match GinaBlameRev /\%%(%s\|%s\)[0-9A-F]\+$/ containedin=GinaBlameBase',
+      \ g:gina#command#blame#formatter#current_mark,
+      \ repeat(' ', len(g:gina#command#blame#formatter#current_mark))
+      \)
+execute printf(
+      \ 'syn match GinaBlameIndicator /%s/ containedin=GinaBlameRev',
+      \ g:gina#command#blame#formatter#current_mark,
+      \)
 syntax match GinaBlameRevColor0  /0/ contained containedin=GinaBlameRev
 syntax match GinaBlameRevColor1  /1/ contained containedin=GinaBlameRev
 syntax match GinaBlameRevColor2  /2/ contained containedin=GinaBlameRev
@@ -36,7 +44,6 @@ syntax match GinaBlameRevColor12 /C/ contained containedin=GinaBlameRev
 syntax match GinaBlameRevColor13 /D/ contained containedin=GinaBlameRev
 syntax match GinaBlameRevColor14 /E/ contained containedin=GinaBlameRev
 syntax match GinaBlameRevColor15 /F/ contained containedin=GinaBlameRev
-syntax match GinaBlameIndicator  /▌/ contained containedin=GinaBlameRev
 
 function! s:define_highlights() abort
   highlight default link GinaBlameBase Comment

--- a/test/vital/Action.vimspec
+++ b/test/vital/Action.vimspec
@@ -384,35 +384,6 @@ Describe Action
                 \ [
                 \   {'word': 'a', '__lnum': 1},
                 \   {'word': 'b', '__lnum': 2},
-                \
-                \   {'word': 'c', '__lnum': 3},
-                \ ],
-                \ {'mods': ''},
-                \])
-        End
-
-        It calls an action/alias of {expr} with marked candidates and returns [{mods}, {action}]
-          " https://github.com/thinca/vim-themis/pull/46
-          Skip vim-themis currently does not support 'sign place' in tests. See #46 on vim-themis
-          let binder = Action.attach([
-                \ {'word': 'a'},
-                \ {'word': 'b'},
-                \ {'word': 'c'},
-                \], {
-                \ 'markable': 1,
-                \})
-          call binder.define('test', Funcref)
-          call setline(1, ['a', 'b', 'c'])
-          call setpos('.', [0, 2, 1, 0])
-          call binder.call('builtin:mark:set', 1)
-          call binder.call('builtin:mark:set', 3)
-
-          let [mods, action] = binder.call('test')
-          Assert Equals(mods, '')
-          Assert Equals(action.name, 'test')
-          Assert Equals(b:_vital_action_test_called_with, [
-                \ [
-                \   {'word': 'a', '__lnum': 1},
                 \   {'word': 'c', '__lnum': 3},
                 \ ],
                 \ {'mods': ''},


### PR DESCRIPTION
I added 'blame' feature. I would like to hear comments before I settle the behaviors.

![selection_062](https://cloud.githubusercontent.com/assets/546312/23340514/dc7aeebe-fc7a-11e6-96c1-7615ae2d9d09.png)

### Syntax:

    :Gina blame [+cmd] [++opt] [{options}] [{treeish}]

### Examples:

    :Gina blame :README.md
    :Gina blame :autoload/gina/process.c -L10,20 -L26,30

### Pros/Cons to vim-gita:

- Pros. Incredibely faster (tested on vim/vim/src/eval.c)
  - vim-gita: approx. 14 s
  - gina.vim: approx.  5 s
- Pros. Better option supports
  - E.g. Annotation limit (-L) was not supported in vim-gita
- Cons. Less visibility
  - vim-gita use pseudo lines to separate each chunks which makes easy to recognize a chunk region
  - gina.vim does not separate chunks for performance reason

### Pros/Cons to vim-fugitive:

- Pros. Good looks
  - vim-fugitive shows a raw format
- Pros. Good navigation
  - <CR> to go the commit or the parent commit
  - <BS> to back
  - j/k to show detail
- Cons. A bit slower (tested on vim/vim/src/eval.c)
  - gina.vim: approx.  5 s
  - fugitive: approx.  3 s
