### PR TITLE
RFC: Improve action

### DIFF
--- a/autoload/gina/action.vim
+++ b/autoload/gina/action.vim
@@ -1,5 +1,9 @@
+scriptencoding utf-8
 let s:Action = vital#gina#import('Action')
 let s:Action.name = 'gina'
+let s:Highlight = vital#gina#import('Vim.Highlight')
+
+
 
 function! gina#action#get(...) abort
   return call(s:Action.get, a:000, s:Action)
@@ -69,7 +73,43 @@ endfunction
 function! gina#action#candidates(...) abort
   let binder = s:Action.get()
   if binder is# v:null
+    " TODO: raise an exception
     return
   endif
-  return gina#core#exception#call(binder.candidates, a:000, binder)
+  return gina#core#exception#call(binder._get_candidates, a:000, binder)
 endfunction
+
+
+" Config ---------------------------------------------------------------------
+call gina#config(expand('<sfile>'), {
+      \ 'mark_sign_text': '|',
+      \})
+
+
+" Highlight ------------------------------------------------------------------
+function! s:define_highlihghts() abort
+  silent let bg = s:Highlight.get('SignColumn')
+  silent let fg = s:Highlight.get('Title')
+  call s:Highlight.set({
+        \ 'name': 'GinaActionMarkSelected',
+        \ 'attrs': {
+        \   'cterm': 'bold',
+        \   'ctermfg': get(fg.attrs, 'ctermfg', '1'),
+        \   'ctermbg': get(bg.attrs, 'ctermbg', 'NONE'),
+        \   'gui': 'bold',
+        \   'guifg': get(fg.attrs, 'guifg', '#ff0000'),
+        \   'guibg': get(bg.attrs, 'guibg', 'NONE'),
+        \ }
+        \}, {
+        \ 'default': 1,
+        \})
+  highlight link VitalActionMarkSelected GinaActionMarkSelected
+  let s:Action.mark_sign_text = g:gina#action#mark_sign_text
+endfunction
+
+augroup gina_action_internal
+  autocmd! *
+  autocmd ColorScheme * call s:define_highlihghts()
+augroup END
+
+call s:define_highlihghts()

--- a/autoload/gina/action.vim
+++ b/autoload/gina/action.vim
@@ -1,13 +1,18 @@
 let s:Action = vital#gina#import('Action')
+let s:Action.name = 'gina'
 
+function! gina#action#get(...) abort
+  return call(s:Action.get, a:000, s:Action)
+endfunction
 
 function! gina#action#attach(...) abort
-  return call(s:Action.attach, ['gina'] + a:000, s:Action)
+  return call(s:Action.attach, a:000, s:Action)
 endfunction
 
 function! gina#action#include(scheme) abort
-  let binder = s:get()
+  let binder = s:Action.get()
   if binder is# v:null
+    " TODO: raise an exception
     return
   endif
   let scheme = substitute(a:scheme, '-', '_', 'g')
@@ -27,17 +32,19 @@ function! gina#action#include(scheme) abort
 endfunction
 
 function! gina#action#alias(...) abort
-  let binder = s:get()
+  let binder = s:Action.get()
   if binder is# v:null
+    " TODO: raise an exception
     return
   endif
-  return call(binder.alias, a:000, binder)
+  return gina#core#exception#call(binder.alias, a:000, binder)
 endfunction
 
 function! gina#action#shorten(action_scheme, ...) abort
   let excludes = get(a:000, 0, [])
-  let binder = s:get()
+  let binder = s:Action.get()
   if binder is# v:null
+    " TODO: raise an exception
     return
   endif
   let action_scheme = substitute(a:action_scheme, '-', '_', 'g')
@@ -50,36 +57,19 @@ function! gina#action#shorten(action_scheme, ...) abort
   endfor
 endfunction
 
-function! gina#action#call(name_or_alias, ...) abort
-  let binder = s:get()
+function! gina#action#call(...) abort
+  let binder = s:Action.get()
   if binder is# v:null
+    " TODO: raise an exception
     return
   endif
-  let candidates = a:0 > 0 ? a:1 : binder.get_candidates(1, line('$'))
-  return gina#core#exception#call(
-        \ binder.call,
-        \ [a:name_or_alias, candidates],
-        \ binder
-        \)
+  return gina#core#exception#call(binder.call, a:000, binder)
 endfunction
 
 function! gina#action#candidates(...) abort
-  let binder = s:get()
+  let binder = s:Action.get()
   if binder is# v:null
     return
   endif
-  if a:0 == 0
-    let fline = 1
-    let lline = line('$')
-  else
-    let fline = get(a:000, 0, 1)
-    let lline = get(a:000, 1, fline)
-  endif
-  return binder.get_candidates(fline, lline)
-endfunction
-
-
-" Private --------------------------------------------------------------------
-function! s:get(...) abort
-  return call(s:Action.get, ['gina'] + a:000, s:Action)
+  return gina#core#exception#call(binder.candidates, a:000, binder)
 endfunction

--- a/autoload/gina/action/branch.vim
+++ b/autoload/gina/action/branch.vim
@@ -83,13 +83,15 @@ function! s:on_checkout(candidates, options) abort
             \ ? candidate.branch
             \ : candidate.rev
       execute printf(
-            \ 'Gina checkout -b %s %s',
+            \ '%s Gina checkout -b %s %s',
+            \ options.mods,
             \ gina#util#shellescape(branch),
             \ gina#util#shellescape(candidate.rev),
             \)
     else
       execute printf(
-            \ 'Gina checkout %s',
+            \ '%s Gina checkout %s',
+            \ options.mods,
             \ gina#util#shellescape(candidate.rev),
             \)
     endif
@@ -110,7 +112,8 @@ function! s:on_new(candidates, options) abort
           \ 'customlist,gina#complete#commit#branch',
           \)
     execute printf(
-          \ 'Gina checkout -b %s %s',
+          \ '%s Gina checkout -b %s %s',
+          \ options.mods,
           \ gina#util#shellescape(name),
           \ gina#util#shellescape(from),
           \)
@@ -131,7 +134,8 @@ function! s:on_move(candidates, options) abort
           \ candidate.branch,
           \)
     execute printf(
-          \ 'Gina branch --move %s %s %s',
+          \ '%s Gina branch --move %s %s %s',
+          \ options.mods,
           \ options.force ? '--force' : '',
           \ gina#util#shellescape(candidate.branch),
           \ gina#util#shellescape(name),
@@ -150,14 +154,16 @@ function! s:on_delete(candidates, options) abort
     let is_remote = !empty(candidate.remote)
     if is_remote
       execute printf(
-            \ 'Gina push --delete %s %s %s',
+            \ '%s Gina push --delete %s %s %s',
+            \ options.mods,
             \ options.force ? '--force' : '',
             \ gina#util#shellescape(candidate.remote),
             \ gina#util#shellescape(candidate.branch),
             \)
     else
       execute printf(
-            \ 'Gina branch --delete %s %s',
+            \ '%s Gina branch --delete %s %s',
+            \ options.mods,
             \ options.force ? '--force' : '',
             \ gina#util#shellescape(candidate.branch),
             \)
@@ -181,7 +187,8 @@ function! s:on_set_upstream_to(candidates, options) abort
           \ upstream, printf('^%s/', candidate.remote), '', ''
           \)
     execute printf(
-          \ 'Gina branch --set-upstream-to=%s %s',
+          \ '%s Gina branch --set-upstream-to=%s %s',
+          \ options.mods,
           \ gina#util#shellescape(upstream),
           \ gina#util#shellescape(candidate.branch),
           \)
@@ -196,7 +203,8 @@ function! s:on_unset_upstream(candidates, options) abort
   let options = extend({}, a:options)
   for candidate in candidates
     execute printf(
-          \ 'Gina branch --unset-upstream %s',
+          \ '%s Gina branch --unset-upstream %s',
+          \ options.mods,
           \ gina#util#shellescape(candidate.branch),
           \)
   endfor

--- a/autoload/gina/action/browse.vim
+++ b/autoload/gina/action/browse.vim
@@ -43,7 +43,8 @@ function! s:on_browse(candidates, options) abort
           \ gina#util#get(candidate, 'path', v:null),
           \)
     execute printf(
-          \ 'Gina browse %s %s %s',
+          \ '%s Gina browse %s %s %s',
+          \ options.mods,
           \ options.exact ? '--exact' : '',
           \ options.yank ? '--yank' : '',
           \ gina#util#shellescape(treeish),

--- a/autoload/gina/action/changes.vim
+++ b/autoload/gina/action/changes.vim
@@ -30,7 +30,8 @@ function! s:on_changes(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina changes %s -- %s',
+          \ '%s Gina changes %s -- %s',
+          \ options.mods,
           \ gina#util#shellescape(printf(options.format, candidate.rev)),
           \ gina#util#shellescape(gina#util#get(candidate, 'residual')),
           \)

--- a/autoload/gina/action/chaperon.vim
+++ b/autoload/gina/action/chaperon.vim
@@ -41,7 +41,8 @@ function! s:on_chaperon(candidates, options) abort
         \}, a:options)
   for candidate in candidates
     execute printf(
-          \ 'Gina chaperon %s %s %s %s',
+          \ '%s Gina chaperon %s %s %s %s',
+          \ options.mods,
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(get(candidate, 'line'), '--line='),
           \ gina#util#shellescape(get(candidate, 'col'), '--col='),

--- a/autoload/gina/action/commit.vim
+++ b/autoload/gina/action/commit.vim
@@ -94,7 +94,8 @@ function! s:on_merge(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina merge --no-edit %s %s %s -- %s',
+          \ '%s Gina merge --no-edit %s %s %s -- %s',
+          \ options.mods,
           \ options['no-ff'] ? '--no-ff' : '',
           \ options['ff-only'] ? '--ff-only' : '',
           \ options.squash ? '--squash' : '',
@@ -112,7 +113,8 @@ function! s:on_rebase(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina rebase %s -- %s',
+          \ '%s Gina rebase %s -- %s',
+          \ options.mods,
           \ options.merge ? '--merge' : '',
           \ gina#util#shellescape(candidate.rev),
           \)
@@ -128,7 +130,8 @@ function! s:on_revert(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina revert %s %s',
+          \ '%s Gina revert %s %s',
+          \ options.mods,
           \ gina#util#shellescape(options.mainline, '--mainline'),
           \ gina#util#shellescape(candidate.rev),
           \)
@@ -144,7 +147,8 @@ function! s:on_cherry_pick(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina cherry-pick %s %s',
+          \ '%s Gina cherry-pick %s %s',
+          \ options.mods,
           \ gina#util#shellescape(options.mainline, '--mainline'),
           \ gina#util#shellescape(candidate.rev),
           \)

--- a/autoload/gina/action/compare.vim
+++ b/autoload/gina/action/compare.vim
@@ -45,7 +45,8 @@ function! s:on_compare(candidates, options) abort
           \ candidate.path,
           \)
     execute printf(
-          \ 'Gina compare %s %s %s %s %s',
+          \ '%s Gina compare %s %s %s %s %s',
+          \ options.mods,
           \ cached ? '--cached' : '',
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(get(candidate, 'line'), '--line='),

--- a/autoload/gina/action/diff.vim
+++ b/autoload/gina/action/diff.vim
@@ -49,7 +49,8 @@ function! s:on_diff(candidates, options) abort
           \ gina#util#get(candidate, 'path', v:null),
           \)
     execute printf(
-          \ 'Gina diff %s %s %s -- %s',
+          \ '%s Gina diff %s %s %s -- %s',
+          \ options.mods,
           \ cached ? '--cached' : '',
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(treeish),

--- a/autoload/gina/action/edit.vim
+++ b/autoload/gina/action/edit.vim
@@ -44,7 +44,8 @@ function! s:on_edit(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina edit %s %s %s %s',
+          \ '%s Gina edit %s %s %s %s',
+          \ options.mods,
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(get(candidate, 'line'), '--line='),
           \ gina#util#shellescape(get(candidate, 'col'), '--col='),

--- a/autoload/gina/action/patch.vim
+++ b/autoload/gina/action/patch.vim
@@ -40,7 +40,8 @@ function! s:on_patch(candidates, options) abort
         \}, a:options)
   for candidate in a:candidates
     execute printf(
-          \ 'Gina patch %s %s %s %s',
+          \ '%s Gina patch %s %s %s %s',
+          \ options.mods,
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(get(candidate, 'line'), '--line='),
           \ gina#util#shellescape(get(candidate, 'col'), '--col='),

--- a/autoload/gina/action/show.vim
+++ b/autoload/gina/action/show.vim
@@ -73,7 +73,8 @@ function! s:on_show(candidates, options) abort
           \ gina#util#get(candidate, 'path', v:null),
           \)
     execute printf(
-          \ 'Gina show %s %s %s %s -- %s',
+          \ '%s Gina show %s %s %s %s -- %s',
+          \ options.mods,
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(get(candidate, 'line'), '--line='),
           \ gina#util#shellescape(get(candidate, 'col'), '--col='),
@@ -96,7 +97,8 @@ function! s:on_commit(candidates, options) abort
           \ v:null
           \)
     execute printf(
-          \ 'Gina show %s %s %s %s -- %s',
+          \ '%s Gina show %s %s %s %s -- %s',
+          \ options.mods,
           \ gina#util#shellescape(options.opener, '--opener='),
           \ gina#util#shellescape(get(candidate, 'line'), '--line='),
           \ gina#util#shellescape(get(candidate, 'col'), '--col='),

--- a/autoload/gina/command/branch.vim
+++ b/autoload/gina/command/branch.vim
@@ -69,7 +69,9 @@ function! s:init(args) abort
 
   " Attach modules
   call gina#core#anchor#attach()
-  call gina#action#attach(function('s:get_candidates'))
+  call gina#action#attach(function('s:get_candidates'), {
+        \ 'markable': 1,
+        \})
   call gina#action#include('branch')
   call gina#action#include('browse')
   call gina#action#include('changes')

--- a/autoload/gina/command/branch.vim
+++ b/autoload/gina/command/branch.vim
@@ -100,19 +100,18 @@ endfunction
 function! s:get_candidates(fline, lline) abort
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val)'
+        \ 's:parse_record(v:val)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record) abort
+function! s:parse_record(record) abort
   let record = s:String.remove_ansi_sequences(a:record)
   let m = matchlist(record, '\(\*\|\s\) \([^ ]\+\)\%( -> \([^ ]\+\)\)\?')
   let remote = matchstr(m[2], '^remotes/\zs[^ /]\+')
   let rev = matchstr(m[2], '^\%(remotes/\)\?\zs[^ ]\+')
   let branch = matchstr(rev, printf('^\%%(%s/\)\?\zs[^ ]\+', remote))
   return {
-        \ 'lnum': a:lnum,
         \ 'word': record,
         \ 'abbr': a:record,
         \ 'sign': m[1],

--- a/autoload/gina/command/changes.vim
+++ b/autoload/gina/command/changes.vim
@@ -87,18 +87,17 @@ function! s:get_candidates(fline, lline) abort
   let residual = args.residual()
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val, rev, residual)'
+        \ 's:parse_record(v:val, rev, residual)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record, rev, residual) abort
+function! s:parse_record(record, rev, residual) abort
   let m = matchlist(
         \ a:record,
         \ '^\(\d\+\)\s\+\(\d\+\)\s\+\(.\+\)$'
         \)
   return empty(m) ? {} : {
-        \ 'lnum': a:lnum,
         \ 'word': a:record,
         \ 'added': m[1],
         \ 'removed': m[2],

--- a/autoload/gina/command/grep.vim
+++ b/autoload/gina/command/grep.vim
@@ -102,12 +102,12 @@ function! s:get_candidates(fline, lline) abort
   let residual = args.residual()
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val, rev, residual)'
+        \ 's:parse_record(v:val, rev, residual)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record, rev, residual) abort
+function! s:parse_record(record, rev, residual) abort
   let record = s:String.remove_ansi_sequences(a:record)
   let m = matchlist(record, '^\%([^:]\+:\)\?\(.*\):\(\d\+\):\(.*\)$')
   if empty(m)
@@ -117,7 +117,6 @@ function! s:parse_record(lnum, record, rev, residual) abort
   let line = str2nr(m[2])
   let col = stridx(m[3], matched) + 1
   let candidate = {
-        \ 'lnum': a:lnum,
         \ 'word': m[3],
         \ 'abbr': a:record,
         \ 'line': line,

--- a/autoload/gina/command/log.vim
+++ b/autoload/gina/command/log.vim
@@ -91,16 +91,15 @@ function! s:get_candidates(fline, lline) abort
   let residual = args.residual()
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val, path, residual)'
+        \ 's:parse_record(v:val, path, residual)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record, path, residual) abort
+function! s:parse_record(record, path, residual) abort
   let record = s:String.remove_ansi_sequences(a:record)
   let rev = matchstr(record, '^[|/\* ]\+\s\+\zs[a-z0-9]\+')
   return empty(rev) ? {} : {
-        \ 'lnum': a:lnum,
         \ 'word': record,
         \ 'abbr': a:record,
         \ 'path': a:path,

--- a/autoload/gina/command/ls.vim
+++ b/autoload/gina/command/ls.vim
@@ -93,14 +93,13 @@ function! s:get_candidates(fline, lline) abort
   let residual = args.residual()
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val, rev, residual)'
+        \ 's:parse_record(v:val, rev, residual)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record, rev, residual) abort
+function! s:parse_record(record, rev, residual) abort
   return {
-        \ 'lnum': a:lnum,
         \ 'word': a:record,
         \ 'path': a:record,
         \ 'rev': a:rev,

--- a/autoload/gina/command/qrep.vim
+++ b/autoload/gina/command/qrep.vim
@@ -23,7 +23,7 @@ function! gina#command#qrep#call(range, args, mods) abort
 
     let items = map(
           \ result.content,
-          \ 's:parse_record(git, 1 + v:key, v:val, rev, residual)',
+          \ 's:parse_record(git, v:val, rev, residual)',
           \)
     call setqflist(
           \ filter(items, '!empty(v:val)'),
@@ -63,10 +63,10 @@ function! s:build_args(git, args) abort
   return args.lock()
 endfunction
 
-function! s:parse_record(git, lnum, record, rev, residual) abort
+function! s:parse_record(git, record, rev, residual) abort
   " Parse record to make a gina candidate and translate it to a quickfix item
   let candidate = gina#command#grep#parse_record(
-        \ a:lnum, a:record, a:rev, a:residual,
+        \ a:record, a:rev, a:residual,
         \)
   if empty(candidate)
     return {}

--- a/autoload/gina/command/reflog.vim
+++ b/autoload/gina/command/reflog.vim
@@ -72,16 +72,15 @@ endfunction
 function! s:get_candidates(fline, lline) abort
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val)'
+        \ 's:parse_record(v:val)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record) abort
+function! s:parse_record(record) abort
   let record = s:String.remove_ansi_sequences(a:record)
   let rev = matchstr(record, '^[a-z0-9]\+')
   return {
-        \ 'lnum': a:lnum,
         \ 'word': record,
         \ 'abbr': a:record,
         \ 'rev': rev,

--- a/autoload/gina/command/status.vim
+++ b/autoload/gina/command/status.vim
@@ -50,7 +50,9 @@ function! s:init(args) abort
 
   " Attach modules
   call gina#core#anchor#attach()
-  call gina#action#attach(function('s:get_candidates'))
+  call gina#action#attach(function('s:get_candidates'), {
+        \ 'markable': 1,
+        \})
   call gina#action#include('browse')
   call gina#action#include('chaperon')
   call gina#action#include('compare')
@@ -91,12 +93,12 @@ function! s:get_candidates(fline, lline) abort
   let residual = args.residual()
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val, residual)'
+        \ 's:parse_record(v:val, residual)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record, residual) abort
+function! s:parse_record(record, residual) abort
   let m = matchlist(
         \ a:record,
         \ '^\(..\) \("[^"]\{-}"\|.\{-}\)\%( -> \("[^"]\{-}"\|[^ ]\+\)\)\?$'
@@ -105,7 +107,6 @@ function! s:parse_record(lnum, record, residual) abort
     return {}
   endif
   let candidate = {
-        \ 'lnum': a:lnum,
         \ 'word': a:record,
         \ 'sign': m[1],
         \ 'residual': a:residual,

--- a/autoload/gina/command/tag.vim
+++ b/autoload/gina/command/tag.vim
@@ -89,14 +89,13 @@ endfunction
 function! s:get_candidates(fline, lline) abort
   let candidates = map(
         \ getline(a:fline, a:lline),
-        \ 's:parse_record(a:fline + v:key, v:val)'
+        \ 's:parse_record(v:val)'
         \)
   return filter(candidates, '!empty(v:val)')
 endfunction
 
-function! s:parse_record(lnum, record) abort
+function! s:parse_record(record) abort
   return {
-        \ 'lnum': a:lnum,
         \ 'word': a:record,
         \ 'branch': a:record,
         \ 'rev': a:record,

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -115,7 +115,6 @@ function! s:binder.define(name, callback, ...) abort
         \ 'mapping_mode': '',
         \ 'requirements': [],
         \ 'options': {},
-        \ 'default': 0,
         \ 'hidden': 0,
         \ 'priority': 0,
         \ 'repeatable': 1,

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -43,8 +43,6 @@ function! s:attach(name, ...) abort
   call binder.alias('echo', 'builtin:echo')
   call binder.alias('help', 'builtin:help')
   call binder.alias('help:all', 'builtin:help:all')
-  call binder.alias('choice', 'builtin:choice')
-  call binder.alias('repeat', 'builtin:repeat')
   let name = substitute(a:name, ':', '-', 'g')
   execute printf('nmap <buffer> ?     <Plug>(%s-builtin-help)', name)
   execute printf('nmap <buffer> <Tab> <Plug>(%s-builtin-choice)', name)

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -3,6 +3,25 @@ let s:t_list = type([])
 
 let s:PREFIX = '_vital_action_binder_'
 let s:UNIQUE = sha256(expand('<sfile>:p'))
+let s:MODIFIERS = [
+      \ 'aboveleft',
+      \ 'belowright',
+      \ 'botright',
+      \ 'browse',
+      \ 'confirm',
+      \ 'hide',
+      \ 'keepalt',
+      \ 'keepjumps',
+      \ 'keepmarks',
+      \ 'keeppatterns',
+      \ 'lockmarks',
+      \ 'noswapfile',
+      \ 'silent',
+      \ 'tab',
+      \ 'topleft',
+      \ 'verbose',
+      \ 'vertical',
+      \]
 
 
 function! s:_vital_loaded(V) abort
@@ -461,16 +480,27 @@ function! s:_find_alias(binder, action) abort
 endfunction
 
 function! s:_complete_action_aliases(arglead, cmdline, cursorpos) abort
+  let terms = split(a:arglead, ' ', 1)
+  " Build modifier candidates
+  let modifiers = terms[:-2]
+  let candidates = map(
+        \ filter(copy(s:MODIFIERS), 'index(modifiers, v:val) == -1'),
+        \ 'v:val . '' '''
+        \)
+  " Build action/alias candidates
+  let arglead = terms[-1]
   let binder = s:_binder
   let actions = values(binder.actions)
-  if empty(a:arglead)
+  if empty(arglead)
     call filter(actions, '!v:val.hidden')
   endif
-  let candidates = sort(extend(
+  call extend(candidates, sort(extend(
         \ map(actions, 'v:val.name'),
         \ keys(binder.aliases),
-        \))
-  return filter(candidates, 'v:val =~# ''^'' . a:arglead')
+        \)), 0)
+  call filter(uniq(candidates), 'v:val =~# ''^'' . arglead')
+  call map(candidates, 'join(modifiers + [v:val])')
+  return candidates
 endfunction
 
 function! s:_call_for_mapping(name) abort range

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -43,22 +43,28 @@ function! s:attach(...) abort dict
   call binder.define('builtin:echo', function('s:_action_echo'), {
         \ 'hidden': 1,
         \ 'description': 'Echo the candidates',
+        \ 'clear_mark': 0,
         \})
   call binder.define('builtin:help', function('s:_action_help'), {
         \ 'description': 'Show help of actions',
         \ 'mapping_mode': 'n',
         \ 'repeatable': 0,
+        \ 'use_mark': 0,
+        \ 'clear_mark': 0,
         \})
   call binder.define('builtin:help:all', function('s:_action_help'), {
         \ 'description': 'Show help of actions including hidden actions',
         \ 'mapping_mode': 'n',
         \ 'options': { 'all': 1 },
         \ 'repeatable': 0,
+        \ 'use_mark': 0,
+        \ 'clear_mark': 0,
         \})
   call binder.define('builtin:choice', function('s:_action_choice'), {
         \ 'description': 'Select action to perform',
         \ 'mapping_mode': 'inv',
         \ 'repeatable': 0,
+        \ 'clear_mark': 0,
         \})
   call binder.define('builtin:repeat', function('s:_action_repeat'), {
         \ 'description': 'Repeat previous repeatable action',
@@ -87,6 +93,7 @@ function! s:attach(...) abort dict
           \ 'mapping_mode': 'nv',
           \ 'requirements': ['lnum'],
           \ 'use_mark': 0,
+          \ 'clear_mark': 0,
           \})
     call binder.define('builtin:mark:set', function('s:_action_mark_set'), {
           \ 'hidden': 1,
@@ -94,6 +101,7 @@ function! s:attach(...) abort dict
           \ 'mapping_mode': 'nv',
           \ 'requirements': ['lnum'],
           \ 'use_mark': 0,
+          \ 'clear_mark': 0,
           \})
     call binder.define('builtin:mark:unset', function('s:_action_mark_unset'), {
           \ 'hidden': 1,
@@ -101,12 +109,14 @@ function! s:attach(...) abort dict
           \ 'mapping_mode': 'nv',
           \ 'requirements': ['lnum'],
           \ 'use_mark': 0,
+          \ 'clear_mark': 0,
           \})
     call binder.define('builtin:mark:unall', function('s:_action_mark_unall'), {
           \ 'hidden': 1,
           \ 'description': 'Unmark all candidate',
           \ 'mapping_mode': 'n',
           \ 'use_mark': 0,
+          \ 'clear_mark': 0,
           \})
     call binder.alias('mark', 'builtin:mark')
     call binder.alias('mark:set', 'builtin:mark:set')
@@ -162,6 +172,7 @@ function! s:binder.define(name, callback, ...) abort
         \ 'hidden': 0,
         \ 'repeatable': 1,
         \ 'use_mark': 1,
+        \ 'clear_mark': 1,
         \}, get(a:000, 0, {}),
         \)
   if empty(action.mapping)
@@ -251,7 +262,7 @@ function! s:binder.call(expr, ...) abort range
         \ 'mods': mods,
         \}, action.options
         \)
-  if self.markable && action.use_mark
+  if self.markable && action.clear_mark
     call self.call('builtin:mark:unall')
   endif
   call call(action.callback, [candidates, options], self)

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -49,7 +49,7 @@ function! s:attach(name, ...) abort
   execute printf('vmap <buffer> <Tab> <Plug>(%s-builtin-choice)', name)
   execute printf('imap <buffer> <Tab> <Plug>(%s-builtin-choice)', name)
   execute printf('nmap <buffer> . <Plug>(%s-builtin-repeat)', name)
-  execute printf('vmap <buffer> . <Plug>(%s-builtin-repeat)gv', name)
+  execute printf('vmap <buffer> . <Plug>(%s-builtin-repeat)', name)
   execute printf('imap <buffer> . <Plug>(%s-builtin-repeat)', name)
   let b:{s:PREFIX . a:name} = binder
   return binder

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -1,4 +1,5 @@
 let s:t_funcref = type(function('tr'))
+let s:t_list = type([])
 
 let s:PREFIX = '_vital_action_binder_'
 let s:UNIQUE = sha256(expand('<sfile>:p'))
@@ -14,6 +15,7 @@ endfunction
 
 function! s:_vital_created(module) abort
   let a:module.name = 'action'
+  let a:module.mark_sign_text = '*'
 endfunction
 
 
@@ -27,9 +29,12 @@ function! s:attach(...) abort dict
         \ '_candidates': get(a:000, 0, v:null),
         \ 'actions': {},
         \ 'aliases': {},
+        \ 'markable': 0,
         \})
+  let binder = extend(binder, get(a:000, 1, {}))
   " Lock methods
-  lockvar binder.candidates
+  lockvar binder._get_candidates
+  lockvar binder._get_marked_candidates
   lockvar binder.define
   lockvar binder.alias
   lockvar binder.action
@@ -70,6 +75,46 @@ function! s:attach(...) abort dict
   execute printf('nmap <buffer> . <Plug>(%s-builtin-repeat)', binder.name)
   execute printf('vmap <buffer> . <Plug>(%s-builtin-repeat)', binder.name)
   execute printf('imap <buffer> . <Plug>(%s-builtin-repeat)', binder.name)
+  if binder.markable
+    execute printf(
+          \ 'sign define %s texthl=%s text=%s',
+          \ 'VitalActionMarkSelectedSign',
+          \ 'VitalActionMarkSelected',
+          \ self.mark_sign_text,
+          \)
+    call binder.define('builtin:mark', function('s:_action_mark'), {
+          \ 'description': 'Mark/Unmark a selected candidate',
+          \ 'mapping_mode': 'nv',
+          \ 'requirements': ['lnum'],
+          \ 'use_mark': 0,
+          \})
+    call binder.define('builtin:mark:set', function('s:_action_mark_set'), {
+          \ 'hidden': 1,
+          \ 'description': 'Mark a selected candidate',
+          \ 'mapping_mode': 'nv',
+          \ 'requirements': ['lnum'],
+          \ 'use_mark': 0,
+          \})
+    call binder.define('builtin:mark:unset', function('s:_action_mark_unset'), {
+          \ 'hidden': 1,
+          \ 'description': 'Unmark a selected candidate',
+          \ 'mapping_mode': 'nv',
+          \ 'requirements': ['lnum'],
+          \ 'use_mark': 0,
+          \})
+    call binder.define('builtin:mark:unall', function('s:_action_mark_unall'), {
+          \ 'hidden': 1,
+          \ 'description': 'Unmark all candidate',
+          \ 'mapping_mode': 'n',
+          \ 'use_mark': 0,
+          \})
+    call binder.alias('mark', 'builtin:mark')
+    call binder.alias('mark:set', 'builtin:mark:set')
+    call binder.alias('mark:unset', 'builtin:mark:unset')
+    call binder.alias('mark:unall', 'builtin:mark:unall')
+    execute printf('nmap <buffer> * <Plug>(%s-builtin-mark)', binder.name)
+    execute printf('vmap <buffer> * <Plug>(%s-builtin-mark)', binder.name)
+  endif
   let b:{s:PREFIX . s:UNIQUE} = binder
   return binder
 endfunction
@@ -78,16 +123,31 @@ endfunction
 " Instance -------------------------------------------------------------------
 let s:binder = {}
 
-function! s:binder.candidates(...) abort
+function! s:binder._get_candidates(...) abort
   let fline = get(a:000, 0, line('.'))
   let lline = get(a:000, 1, fline)
   if self._candidates is v:null
-    return getline(fline, lline)
+    let candidates = getline(fline, lline)
   elseif type(self._candidates) == s:t_funcref
-    return self._candidates(fline, lline)
+    let candidates = self._candidates(fline, lline)
   else
-    return self._candidates[fline : lline]
+    let candidates = self._candidates[fline : lline]
   endif
+  return map(
+        \ deepcopy(candidates),
+        \ 'extend(v:val, {''lnum'': fline + v:key})'
+        \)
+endfunction
+
+function! s:binder._get_marked_candidates() abort
+  if !self.markable
+    throw 'vital: Action: The action binder is not markable'
+  endif
+  let signs = s:_get_signs()
+  let lnums = map(signs, 'v:val.line')
+  let candidates = []
+  call map(lnums, 'extend(candidates, self._get_candidates(v:val, v:val))')
+  return candidates
 endfunction
 
 function! s:binder.define(name, callback, ...) abort
@@ -101,6 +161,7 @@ function! s:binder.define(name, callback, ...) abort
         \ 'options': {},
         \ 'hidden': 0,
         \ 'repeatable': 1,
+        \ 'use_mark': 1,
         \}, get(a:000, 0, {}),
         \)
   if empty(action.mapping)
@@ -167,7 +228,16 @@ endfunction
 
 function! s:binder.call(expr, ...) abort range
   let [mods, action] = self.action(a:expr)
-  let candidates = copy(a:0 ? a:1 : self.candidates())
+  if a:0 == 1 && type(a:1) == s:t_list
+    let candidates = a:1
+  elseif self.markable && action.use_mark
+    let candidates = self._get_marked_candidates()
+    let candidates = empty(candidates)
+          \ ? call(self._get_candidates, a:000, self)
+          \ : candidates
+  else
+    let candidates = call(self._get_candidates, a:000, self)
+  endif
   if !empty(action.requirements)
     call filter(
           \ candidates,
@@ -181,6 +251,9 @@ function! s:binder.call(expr, ...) abort range
         \ 'mods': mods,
         \}, action.options
         \)
+  if self.markable && action.use_mark
+    call self.call('builtin:mark:unall')
+  endif
   call call(action.callback, [candidates, options], self)
   return action
 endfunction
@@ -271,6 +344,53 @@ function! s:_action_repeat(candidates, options) abort dict
   return self.call(action.name, a:candidates)
 endfunction
 
+function! s:_action_mark(candidates, options) abort dict
+  let set_candidates = []
+  let unset_candidates = []
+  let signmap = s:_get_signmap()
+  for candidate in a:candidates
+    if has_key(signmap, string(candidate.lnum))
+      call add(unset_candidates, candidate)
+    else
+      call add(set_candidates, candidate)
+    endif
+  endfor
+  call self.call('mark:set', set_candidates)
+  call self.call('mark:unset', unset_candidates)
+endfunction
+
+function! s:_action_mark_set(candidates, options) abort dict
+  let options = extend({}, a:options)
+  let lnums = map(a:candidates, 'v:val.lnum')
+  let bufnr = bufnr('%')
+  for lnum in lnums
+    execute printf(
+          \ 'sign place %d line=%d name=%s buffer=%d',
+          \ lnum, lnum,
+          \ 'VitalActionMarkSelectedSign',
+          \ bufnr,
+          \)
+  endfor
+endfunction
+
+function! s:_action_mark_unset(candidates, options) abort dict
+  let options = extend({}, a:options)
+  let lnums = map(a:candidates, 'v:val.lnum')
+  let bufnr = bufnr('%')
+  for lnum in lnums
+    execute printf(
+          \ 'sign unplace %d buffer=%d',
+          \ lnum, bufnr,
+          \)
+  endfor
+endfunction
+
+function! s:_action_mark_unall(candidates, options) abort dict
+  let options = extend({}, a:options)
+  let bufnr = bufnr('%')
+  execute printf('sign unplace * buffer=%d', bufnr)
+endfunction
+
 
 " Privates -------------------------------------------------------------------
 function! s:_is_satisfied(candidate, requirements) abort
@@ -344,10 +464,35 @@ endfunction
 
 function! s:_call_for_mapping(name) abort range
   let binder = s:get()
-  let candidates = binder.candidates(a:firstline, a:lastline)
-  return s:Exception.call(binder.call, [a:name, candidates], binder)
+  return s:Exception.call(binder.call, [a:name, a:firstline, a:lastline], binder)
 endfunction
 
+function! s:_get_signs() abort
+  let content = split(s:_execute('sign place buffer=' . bufnr('%')), '\r\?\n')
+  let signs = map(
+        \ filter(content, 'v:val =~# ''^\s\{4}'''),
+        \ 's:_parse_sign(v:val)',
+        \)
+  return filter(signs, 'v:val.name ==# ''VitalActionMarkSelectedSign''')
+endfunction
+
+function! s:_get_signmap() abort
+  let signmap = {}
+  for sign in s:_get_signs()
+    let signmap[sign.line] = sign
+  endfor
+  return signmap
+endfunction
+
+function! s:_parse_sign(sign) abort
+  let terms = split(a:sign)
+  let sign = {}
+  for term in terms
+    let m = split(term, '=')
+    let sign[m[0]] = m[1]
+  endfor
+  return sign
+endfunction
 
 " Compatibility --------------------------------------------------------------
 if has('patch-7.4.1842')
@@ -373,3 +518,16 @@ else
     return content
   endfunction
 endif
+
+
+" Highlight ------------------------------------------------------------------
+function! s:_define_mark_highlights() abort
+  highlight default link VitalActionMarkSelected SignColumn
+endfunction
+
+augroup vital_action_mark_internal
+  autocmd! *
+  autocmd ColorScheme * call s:_define_mark_highlights()
+augroup END
+
+call s:_define_mark_highlights()

--- a/autoload/vital/__gina__/Action.vim
+++ b/autoload/vital/__gina__/Action.vim
@@ -345,7 +345,7 @@ endfunction
 function! s:_call_for_mapping(name) abort range
   let binder = s:get()
   let candidates = binder.candidates(a:firstline, a:lastline)
-  return binder.call(a:name, candidates)
+  return s:Exception.call(binder.call, [a:name, candidates], binder)
 endfunction
 
 

--- a/doc/gina-develop.txt
+++ b/doc/gina-develop.txt
@@ -388,7 +388,11 @@ update a quickfix candidates with gina-grep candidates automatically, use
 	  endif
 	  " Export entire candidates into a quickfic and restore the focus
 	  try
-	    call gina#action#call('export:quickfix')
+	    let candidates = gina#action#candidates(1, line('$'))
+	    call gina#action#call(
+	          \ 'export:quickfix',
+	          \ candidates,
+	          \)
 	  finally
 	    call focus.restore()
 	  endtry

--- a/doc/gina-develop.txt
+++ b/doc/gina-develop.txt
@@ -388,10 +388,9 @@ update a quickfix candidates with gina-grep candidates automatically, use
 	  endif
 	  " Export entire candidates into a quickfic and restore the focus
 	  try
-	    let candidates = gina#action#candidates(1, line('$'))
 	    call gina#action#call(
 	          \ 'export:quickfix',
-	          \ candidates,
+	          \ 1, line('$')
 	          \)
 	  finally
 	    call focus.restore()

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -220,6 +220,14 @@ Each columns in the message indicates
 
 If you would like to define custom aliases or mappings, see the next section.
 
+						*gina-usage-action-mods*
+Most of actions support command modifiers. For example, if you would like to
+see a debug message on the action, prepend |verbose| modifier like
+>
+	action: verbose show
+<
+When you hit <CR>, the "show" action will be executed with |verbose| modifier.
+
 
 =============================================================================
 CUSTOM						*gina-custom*

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -36,6 +36,7 @@ INTERFACE			|gina-interface|
   COMMANDS			  |gina-commands|
   FUNCTIONS			  |gina-functions|
   VARIABLES			  |gina-variables|
+  HIGHLIGHTS			  |gina-highlights|
   OPTIONS			  |gina-options|
   ACTIONS			  |gina-actions|
 MISC				|gina-misc|
@@ -227,6 +228,18 @@ see a debug message on the action, prepend |verbose| modifier like
 	action: verbose show
 <
 When you hit <CR>, the "show" action will be executed with |verbose| modifier.
+
+						*gina-usage-action-mark*
+Actions in some buffer are defined as "markable", mean that users can mark
+candidates by "builtin:mark" action and all further actions are applied to the
+selected candidates.
+In default, the "builtin:mark" action is mapped to "*" if the buffer allowed
+mark. Note that marks are removed after users call any actions.
+
+To customize the mark, users can use the followings
+
+|g:gina#action#mark_sign_text|
+|hl-GinaActionMarkSelected|
 
 
 =============================================================================
@@ -641,6 +654,9 @@ Users can disable the default aliases (shorten) and/or mappings by
 
 Set 0 to these value disable default settings.
 
+Note that actions are defined as "markable" in this buffer.
+See |gina-usage-action-mark| for the detail.
+
 -----------------------------------------------------------------------------
 CHANGES						*gina-buffer-changes*
 					{scheme}:	changes
@@ -874,6 +890,9 @@ Users can disable the default aliases (shorten) and/or mappings by
 	|g:gina#command#status#use_default_mappings|
 
 Set 0 to these value disable default settings.
+
+Note that actions are defined as "markable" in this buffer.
+See |gina-usage-action-mark| for the detail.
 
 -----------------------------------------------------------------------------
 TAG						*gina-buffer-tag*
@@ -1394,6 +1413,12 @@ gina#custom#mapping#imap({scheme}, {lhs}, {rhs} [, {options}])
 -----------------------------------------------------------------------------
 VARIABLES					*gina-variables*
 
+		*g:gina#action#mark_sign_text*
+g:gina#action#mark_sign_text
+	One or two characters used for a mark |sign|.
+	See |gina-usage-action-mark| for what the mark is.
+	Default: "|"
+
 		*g:gina#command#branch#use_default_aliases*
 		*g:gina#command#changes#use_default_aliases*
 		*g:gina#command#grep#use_default_aliases*
@@ -1532,6 +1557,14 @@ g:gina#core#writer#use_python
 g:gina#core#writer#use_python3
 	Use |python3| to update the buffer content if available.
 	Default: 1
+
+-----------------------------------------------------------------------------
+HIGHLIGHTS					*gina-highlights*
+
+						*hl-GinaActionMarkSelected*
+GinaActionMarkSelected
+	A highlight used for a mark sign text.
+	See |gina-usage-action-mark| for what the mark is.
 
 -----------------------------------------------------------------------------
 OPTIONS						*gina-options*

--- a/ftplugin/gina-grep.vim
+++ b/ftplugin/gina-grep.vim
@@ -38,8 +38,7 @@ if g:gina#command#grep#send_to_quickfix
       return
     endif
     try
-      let candidates = gina#action#candidates(1, line('$'))
-      call gina#action#call('export:quickfix', candidates)
+      call gina#action#call('export:quickfix', 1, line('$'))
     finally
       call focus.restore()
     endtry

--- a/ftplugin/gina-grep.vim
+++ b/ftplugin/gina-grep.vim
@@ -38,7 +38,8 @@ if g:gina#command#grep#send_to_quickfix
       return
     endif
     try
-      call gina#action#call('export:quickfix')
+      let candidates = gina#action#candidates(1, line('$'))
+      call gina#action#call('export:quickfix', candidates)
     finally
       call focus.restore()
     endtry

--- a/syntax/gina-_events.vim
+++ b/syntax/gina-_events.vim
@@ -7,8 +7,17 @@ syntax match GinaEventsTime /\d\{2}:\d\{2}:\d\{2}\.\d\{6}/
 syntax match GinaEventsComment /^| .*$/
 syntax match GinaEventsComment /<.\{-}>$/
 
-highlight default link GinaEventsComment Comment
-highlight default link GinaEventsPrefix  Statement
-highlight default link GinaEventsTime    Title
+function! s:define_highlights() abort
+  highlight default link GinaEventsComment Comment
+  highlight default link GinaEventsPrefix  Statement
+  highlight default link GinaEventsTime    Title
+endfunction
+
+augroup gina_syntax__events_internal
+  autocmd! *
+  autocmd ColorScheme * call s:define_highlights()
+augroup END
+
+call s:define_highlights()
 
 let b:current_syntax = 'gina-_events'

--- a/syntax/gina-changes.vim
+++ b/syntax/gina-changes.vim
@@ -2,12 +2,21 @@ if exists('b:current_syntax')
   finish
 endif
 
-syntax match GinaAdded /^\d\+/ nextgroup=GinaRemoved skipwhite
-syntax match GinaRemoved /\d\+/ nextgroup=GinaPath skipwhite contained
-syntax match GinaPath /.\+/ contained
+syntax match GinaChangesAdded /^\d\+/ nextgroup=GinaChangesRemoved skipwhite
+syntax match GinaChangesRemoved /\d\+/ nextgroup=GinaChangesPath skipwhite contained
+syntax match GinaChangesPath /.\+/ contained
 
-highlight default link GinaAdded   Statement
-highlight default link GinaRemoved Constant
-highlight default link GinaPath    Comment
+function! s:define_highlights() abort
+  highlight default link GinaChangesAdded   Statement
+  highlight default link GinaChangesRemoved Constant
+  highlight default link GinaChangesPath    Comment
+endfunction
+
+augroup gina_syntax_changes_internal
+  autocmd! *
+  autocmd ColorScheme * call s:define_highlights()
+augroup END
+
+call s:define_highlights()
 
 let b:current_syntax = 'gina-changes'

--- a/syntax/gina-status.vim
+++ b/syntax/gina-status.vim
@@ -9,11 +9,21 @@ syntax match GinaStatusIgnored /^!! .*$/
 syntax match GinaStatusUntracked /^?? .*$/
 syntax match GinaStatusConflicted /^\%(DD\|AU\|UD\|UA\|DU\|AA\|UU\) .*$/
 
-highlight default link GinaStatusConflicted Error
-highlight default link GinaStatusStaged     Special
-highlight default link GinaStatusUnstaged   Comment
-highlight default link GinaStatusPatched    Constant
-highlight default link GinaStatusUntracked  GinaUnstaged
-highlight default link GinaStatusIgnored    Identifier
+
+function! s:define_highlights() abort
+  highlight default link GinaStatusConflicted Error
+  highlight default link GinaStatusStaged     Special
+  highlight default link GinaStatusUnstaged   Comment
+  highlight default link GinaStatusPatched    Constant
+  highlight default link GinaStatusUntracked  GinaUnstaged
+  highlight default link GinaStatusIgnored    Identifier
+endfunction
+
+augroup gina_syntax_status_internal
+  autocmd! *
+  autocmd ColorScheme * call s:define_highlights()
+augroup END
+
+call s:define_highlights()
 
 let b:current_syntax = 'gina-status'

--- a/test/gina/command/branch.vimspec
+++ b/test/gina/command/branch.vimspec
@@ -48,7 +48,7 @@ Describe gina#command#branch
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'abbr': '  develop[m',
             \   'word': '  develop',
             \   'sign': ' ',
@@ -58,7 +58,7 @@ Describe gina#command#branch
             \   'rev': 'develop',
             \ },
             \ {
-            \   'lnum': 2,
+            \   '__lnum': 2,
             \   'abbr': '* [32mmaster[m',
             \   'word': '* master',
             \   'sign': '*',
@@ -79,7 +79,7 @@ Describe gina#command#branch
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'abbr': '  [31mext/master[m',
             \   'word': '  ext/master',
             \   'sign': ' ',
@@ -102,7 +102,7 @@ Describe gina#command#branch
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'abbr': '  develop[m',
             \   'word': '  develop',
             \   'sign': ' ',
@@ -112,7 +112,7 @@ Describe gina#command#branch
             \   'rev': 'develop',
             \ },
             \ {
-            \   'lnum': 2,
+            \   '__lnum': 2,
             \   'abbr': '* [32mmaster[m',
             \   'word': '* master',
             \   'sign': '*',
@@ -122,7 +122,7 @@ Describe gina#command#branch
             \   'rev': 'master',
             \ },
             \ {
-            \   'lnum': 3,
+            \   '__lnum': 3,
             \   'abbr': '  [31mremotes/ext/master[m',
             \   'word': '  remotes/ext/master',
             \   'sign': ' ',

--- a/test/gina/command/branch.vimspec
+++ b/test/gina/command/branch.vimspec
@@ -46,7 +46,7 @@ Describe gina#command#branch
             \ '  develop[m',
             \ '* [32mmaster[m',
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'abbr': '  develop[m',
@@ -77,7 +77,7 @@ Describe gina#command#branch
       Assert Equals(getline(1, '$'), [
             \ '  [31mext/master[m',
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'abbr': '  [31mext/master[m',
@@ -100,7 +100,7 @@ Describe gina#command#branch
             \ '* [32mmaster[m',
             \ '  [31mremotes/ext/master[m',
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'abbr': '  develop[m',

--- a/test/gina/command/changes.vimspec
+++ b/test/gina/command/changes.vimspec
@@ -44,7 +44,7 @@ Describe gina#command#changes
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'residual': [],
             \   'word': "1\t0\tA/foo.txt",
             \   'path': 'A/foo.txt',
@@ -64,7 +64,7 @@ Describe gina#command#changes
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'residual': [],
             \   'word': "0\t0\tC/foo.txt",
             \   'path': 'C/foo.txt',
@@ -85,7 +85,7 @@ Describe gina#command#changes
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'residual': [],
             \   'word': "0\t0\tC/foo.txt",
             \   'path': 'C/foo.txt',
@@ -105,7 +105,7 @@ Describe gina#command#changes
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'residual': ['A/*.txt'],
             \   'word': "1\t0\tA/foo.txt",
             \   'path': 'A/foo.txt',

--- a/test/gina/command/changes.vimspec
+++ b/test/gina/command/changes.vimspec
@@ -42,7 +42,7 @@ Describe gina#command#changes
       Assert Equals(getline(1, '$'), [
             \ "1\t0\tA/foo.txt",
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'residual': [],
@@ -62,7 +62,7 @@ Describe gina#command#changes
       Assert Equals(getline(1, '$'), [
             \ "0\t0\tC/foo.txt",
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'residual': [],
@@ -83,7 +83,7 @@ Describe gina#command#changes
       Assert Equals(getline(1, '$'), [
             \ "0\t0\tC/foo.txt",
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'residual': [],
@@ -103,7 +103,7 @@ Describe gina#command#changes
       Assert Equals(getline(1, '$'), [
             \ "1\t0\tA/foo.txt",
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'residual': ['A/*.txt'],

--- a/test/gina/command/grep.vimspec
+++ b/test/gina/command/grep.vimspec
@@ -30,7 +30,7 @@ Describe gina#command#grep
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'word': 'a',
             \   'col': 1,
             \   'residual': [],
@@ -40,7 +40,7 @@ Describe gina#command#grep
             \   'abbr': 'A/foo.txt[36m:[m1[36m:[m[1;31ma[m'
             \ },
             \ {
-            \   'lnum': 2,
+            \   '__lnum': 2,
             \   'word': 'aa',
             \   'col': 1,
             \   'residual': [],
@@ -66,7 +66,7 @@ Describe gina#command#grep
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'word': 'a',
             \   'col': 1,
             \   'residual': [],
@@ -76,7 +76,7 @@ Describe gina#command#grep
             \   'abbr': 'A/foo.txt[36m:[m1[36m:[m[1;31ma[m'
             \ },
             \ {
-            \   'lnum': 2,
+            \   '__lnum': 2,
             \   'word': 'b',
             \   'col': 1,
             \   'residual': [],
@@ -86,7 +86,7 @@ Describe gina#command#grep
             \   'abbr': 'A/foo.txt[36m:[m2[36m:[m[1;31mb[m'
             \ },
             \ {
-            \   'lnum': 3,
+            \   '__lnum': 3,
             \   'word': 'aa',
             \   'col': 1,
             \   'residual': [],
@@ -96,7 +96,7 @@ Describe gina#command#grep
             \   'abbr': 'C/foo.txt[36m:[m1[36m:[m[1;31ma[m[1;31ma[m'
             \ },
             \ {
-            \   'lnum': 4,
+            \   '__lnum': 4,
             \   'word': 'bb',
             \   'col': 1,
             \   'residual': [],
@@ -119,7 +119,7 @@ Describe gina#command#grep
             \])
       Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
-            \   'lnum': 1,
+            \   '__lnum': 1,
             \   'word': 'a',
             \   'col': 1,
             \   'residual': ['A/*.txt'],

--- a/test/gina/command/grep.vimspec
+++ b/test/gina/command/grep.vimspec
@@ -28,7 +28,7 @@ Describe gina#command#grep
             \ 'A/foo.txt[36m:[m1[36m:[m[1;31ma[m',
             \ 'C/foo.txt[36m:[m1[36m:[m[1;31ma[m[1;31ma[m',
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'word': 'a',
@@ -64,7 +64,7 @@ Describe gina#command#grep
             \ 'C/foo.txt[36m:[m1[36m:[m[1;31ma[m[1;31ma[m',
             \ 'C/foo.txt[36m:[m2[36m:[m[1;31mb[m[1;31mb[m',
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'word': 'a',
@@ -117,7 +117,7 @@ Describe gina#command#grep
       Assert Equals(getline(1, '$'), [
             \ 'A/foo.txt[36m:[m1[36m:[m[1;31ma[m',
             \])
-      Assert Equals(gina#action#candidates(), [
+      Assert Equals(gina#action#candidates(1, line('$')), [
             \ {
             \   'lnum': 1,
             \   'word': 'a',

--- a/test/gina/custom/action.vimspec
+++ b/test/gina/custom/action.vimspec
@@ -19,27 +19,28 @@ Describe gina#custom#action
       call gina#custom#action#alias(scheme, 'doc', 'builtin:help')
       GinaSync status
       let result = execute('call gina#action#call(''doc'')')
-      Assert Match(result, 'builtin:help \[help\]')
+      Assert Match(result, 'builtin:help \[doc\]')
       Assert Match(result, 'builtin:help:all \[help:all\]')
       GinaSync branch
       let result = execute('call gina#action#call(''doc'')')
-      Assert Match(result, 'No action "doc" is found')
+      Assert Match(result, 'No corresponding action')
       GinaSync tag
       let result = execute('call gina#action#call(''doc'')')
-      Assert Match(result, 'No action "doc" is found')
+      Assert Match(result, 'No corresponding action')
     End
 
     It define an alias of {origin} to {alias} in buffers which match with /{pattern}
       call gina#custom#action#alias(pattern, 'doc', 'builtin:help')
       GinaSync status
       let result = execute('call gina#action#call(''doc'')')
+      Assert Match(result, 'No corresponding action')
       GinaSync branch
       let result = execute('call gina#action#call(''doc'')')
-      Assert Match(result, 'builtin:help \[help\]')
+      Assert Match(result, 'builtin:help \[doc\]')
       Assert Match(result, 'builtin:help:all \[help:all\]')
       GinaSync tag
       let result = execute('call gina#action#call(''doc'')')
-      Assert Match(result, 'builtin:help \[help\]')
+      Assert Match(result, 'builtin:help \[doc\]')
       Assert Match(result, 'builtin:help:all \[help:all\]')
     End
   End

--- a/test/vital/Action.vimspec
+++ b/test/vital/Action.vimspec
@@ -10,7 +10,6 @@ Describe Action
   Describe .attach([{candidates}])
     It returns an instance of Action
       let binder = Action.attach()
-      Assert KeyExists(binder, 'candidates')
       Assert KeyExists(binder, 'define')
       Assert KeyExists(binder, 'alias')
       Assert KeyExists(binder, 'action')

--- a/test/vital/Action.vimspec
+++ b/test/vital/Action.vimspec
@@ -7,20 +7,18 @@ Describe Action
     %bwipeout!
   End
 
-  Describe .attach({name}[, {candidates}])
+  Describe .attach([{candidates}])
     It returns an instance of Action
-      let binder = Action.attach('action')
-      Assert KeyExists(binder, 'get_alias')
-      Assert KeyExists(binder, 'get_action')
-      Assert KeyExists(binder, 'get_candidates')
+      let binder = Action.attach()
+      Assert KeyExists(binder, 'candidates')
       Assert KeyExists(binder, 'define')
       Assert KeyExists(binder, 'alias')
+      Assert KeyExists(binder, 'action')
       Assert KeyExists(binder, 'call')
-      Assert KeyExists(binder, 'smart_map')
     End
 
     It defines builtin actions
-      let binder = Action.attach('action')
+      let binder = Action.attach()
       Assert Equals(sort(keys(binder.actions)), sort([
             \ 'builtin:echo',
             \ 'builtin:help',
@@ -31,7 +29,7 @@ Describe Action
     End
 
     It defines default aliases
-      let binder = Action.attach('action')
+      let binder = Action.attach()
       Assert Equals(sort(keys(binder.aliases)), sort([
             \ 'echo',
             \ 'help',
@@ -40,7 +38,7 @@ Describe Action
     End
 
     It defines default mappings
-      call Action.attach('action')
+      call Action.attach()
       Assert Equals(mapcheck('?', 'n'), '<Plug>(action-builtin-help)')
       Assert Equals(mapcheck('<Tab>', 'n'), '<Plug>(action-builtin-choice)')
       Assert Equals(mapcheck('<Tab>', 'v'), '<Plug>(action-builtin-choice)')
@@ -51,29 +49,12 @@ Describe Action
     End
   End
 
-  Describe .get({name})
+  Describe .get()
     It returns an attached Action instance
-      let binder1 = Action.attach('action')
-      let binder2 = Action.get('action')
+      let binder1 = Action.attach()
+      let binder2 = Action.get()
       Assert Same(binder1, binder2)
     End
   End
 
-  Describe Instance
-    Before
-      let binder = Action.attach('action')
-    End
-
-    Describe .get_alias({name})
-      It returns an alias name of an action
-        let result = binder.get_alias('builtin:echo')
-        Assert Equals(result, 'echo')
-      End
-
-      It returns {name} if no alias is found
-        let result = binder.get_alias('foobar')
-        Assert Equals(result, 'foobar')
-      End
-    End
-  End
 End

--- a/test/vital/Action.vimspec
+++ b/test/vital/Action.vimspec
@@ -36,8 +36,6 @@ Describe Action
             \ 'echo',
             \ 'help',
             \ 'help:all',
-            \ 'choice',
-            \ 'repeat',
             \]))
     End
 
@@ -48,7 +46,7 @@ Describe Action
       Assert Equals(mapcheck('<Tab>', 'v'), '<Plug>(action-builtin-choice)')
       Assert Equals(mapcheck('<Tab>', 'i'), '<Plug>(action-builtin-choice)')
       Assert Equals(mapcheck('.', 'n'), '<Plug>(action-builtin-repeat)')
-      Assert Equals(mapcheck('.', 'v'), '<Plug>(action-builtin-repeat)gv')
+      Assert Equals(mapcheck('.', 'v'), '<Plug>(action-builtin-repeat)')
       Assert Equals(mapcheck('.', 'i'), '<Plug>(action-builtin-repeat)')
     End
   End

--- a/test/vital/Action.vimspec
+++ b/test/vital/Action.vimspec
@@ -1,23 +1,50 @@
 Describe Action
-  Before
+  Before all
     let Action = vital#gina#import('Action')
+
+    function! s:_vital_action_test(...) abort
+      let b:_vital_action_test_called_with = a:000
+    endfunction
+
+    let Funcref = function('s:_vital_action_test')
   End
 
-  After
+  After all
     %bwipeout!
   End
 
-  Describe .attach([{candidates}])
-    It returns an instance of Action
-      let binder = Action.attach()
+  Before
+    %bwipeout!
+  End
+
+  Describe .get()
+    It returns an attached action binder instance
+      let binder1 = Action.attach([])
+      let binder2 = Action.get()
+      Assert Same(binder1, binder2)
+    End
+
+    It returns v:null if no action binder has attached
+      let binder = Action.get()
+      Assert True(binder is# v:null)
+    End
+  End
+
+  Describe .attach({candidates} [, {options}])
+    It returns an instance of action binder
+      let binder = Action.attach([])
       Assert KeyExists(binder, 'define')
       Assert KeyExists(binder, 'alias')
       Assert KeyExists(binder, 'action')
       Assert KeyExists(binder, 'call')
+      Assert IsFunction(binder.define)
+      Assert IsFunction(binder.alias)
+      Assert IsFunction(binder.action)
+      Assert IsFunction(binder.call)
     End
 
     It defines builtin actions
-      let binder = Action.attach()
+      let binder = Action.attach([])
       Assert Equals(sort(keys(binder.actions)), sort([
             \ 'builtin:echo',
             \ 'builtin:help',
@@ -25,19 +52,41 @@ Describe Action
             \ 'builtin:choice',
             \ 'builtin:repeat',
             \]))
+
+      let binder = Action.attach([], {'markable': 1})
+      Assert Equals(sort(keys(binder.actions)), sort([
+            \ 'builtin:echo',
+            \ 'builtin:help',
+            \ 'builtin:help:all',
+            \ 'builtin:choice',
+            \ 'builtin:repeat',
+            \ 'builtin:mark',
+            \ 'builtin:mark:set',
+            \ 'builtin:mark:unset',
+            \ 'builtin:mark:unall',
+            \]))
     End
 
     It defines default aliases
-      let binder = Action.attach()
+      let binder = Action.attach([])
       Assert Equals(sort(keys(binder.aliases)), sort([
             \ 'echo',
             \ 'help',
             \ 'help:all',
             \]))
+
+      let binder = Action.attach([], {'markable': 1})
+      Assert Equals(sort(keys(binder.aliases)), sort([
+            \ 'echo',
+            \ 'help',
+            \ 'help:all',
+            \ 'mark',
+            \ 'mark:unall',
+            \]))
     End
 
     It defines default mappings
-      call Action.attach()
+      call Action.attach([])
       Assert Equals(mapcheck('?', 'n'), '<Plug>(action-builtin-help)')
       Assert Equals(mapcheck('<Tab>', 'n'), '<Plug>(action-builtin-choice)')
       Assert Equals(mapcheck('<Tab>', 'v'), '<Plug>(action-builtin-choice)')
@@ -45,15 +94,372 @@ Describe Action
       Assert Equals(mapcheck('.', 'n'), '<Plug>(action-builtin-repeat)')
       Assert Equals(mapcheck('.', 'v'), '<Plug>(action-builtin-repeat)')
       Assert Equals(mapcheck('.', 'i'), '<Plug>(action-builtin-repeat)')
+
+      call Action.attach([], {'markable': 1})
+      Assert Equals(mapcheck('?', 'n'), '<Plug>(action-builtin-help)')
+      Assert Equals(mapcheck('<Tab>', 'n'), '<Plug>(action-builtin-choice)')
+      Assert Equals(mapcheck('<Tab>', 'v'), '<Plug>(action-builtin-choice)')
+      Assert Equals(mapcheck('<Tab>', 'i'), '<Plug>(action-builtin-choice)')
+      Assert Equals(mapcheck('.', 'n'), '<Plug>(action-builtin-repeat)')
+      Assert Equals(mapcheck('.', 'v'), '<Plug>(action-builtin-repeat)')
+      Assert Equals(mapcheck('.', 'i'), '<Plug>(action-builtin-repeat)')
+      Assert Equals(mapcheck('*', 'n'), '<Plug>(action-builtin-mark)')
+      Assert Equals(mapcheck('*', 'v'), '<Plug>(action-builtin-mark)')
     End
   End
 
-  Describe .get()
-    It returns an attached Action instance
-      let binder1 = Action.attach()
-      let binder2 = Action.get()
-      Assert Same(binder1, binder2)
+  Describe binder instance
+    Describe .define({name}, {callback} [, {options}])
+      It defines a new action with {name} and {callback}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        Assert Equals(binder.actions['test'], {
+              \ 'callback': Funcref,
+              \ 'name': 'test',
+              \ 'description': '',
+              \ 'mapping': '<Plug>(action-test)',
+              \ 'mapping_mode': '',
+              \ 'requirements': [],
+              \ 'options': {},
+              \ 'hidden': 0,
+              \ 'repeatable': 1,
+              \ 'use_marks': 1,
+              \ 'clear_marks': 1,
+              \})
+      End
+
+      It defines <Plug> mappings of the action
+        let binder = Action.attach([])
+        call binder.define('test', Funcref, {
+              \ 'mapping_mode': 'nvi',
+              \})
+        Assert Match(
+              \ mapcheck('<Plug>(action-test)', 'n'),
+              \ ':<C-U>call <SNR>\d\+__call_for_mapping(''test'')<CR>'
+              \)
+        Assert Match(
+              \ mapcheck('<Plug>(action-test)', 'v'),
+              \ ':call <SNR>\d\+__call_for_mapping(''test'')<CR>'
+              \)
+        Assert Match(
+              \ mapcheck('<Plug>(action-test)', 'i'),
+              \ '<Esc>:<C-U>call <SNR>\d\+__call_for_mapping(''test'')<CR>'
+              \)
+      End
+    End
+
+    Describe .alias({alias}, {expr} [, {options}])
+      It defines an alias to {expr}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        call binder.alias('t', 'test')
+        Assert Equals(binder.aliases['t'], {
+              \ 'name': 'test',
+              \ 'expr': 'test',
+              \ 'alias': 't',
+              \})
+
+        call binder.alias('tv', 'verbose test')
+        Assert Equals(binder.aliases['tv'], {
+              \ 'name': 'test',
+              \ 'expr': 'verbose test',
+              \ 'alias': 'tv',
+              \})
+      End
+    End
+
+    Describe .action({expr})
+      It returns [{mods}, {action}] for an existing action
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        let [mods, action] = binder.action('test')
+        Assert Equals(mods, '')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose test')
+        Assert Equals(mods, 'verbose ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose topleft test')
+        Assert Equals(mods, 'verbose topleft ')
+        Assert Equals(action.name, 'test')
+      End
+
+      It returns [{mods}, {action}] for an existing alias
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        call binder.alias('t', 'test')
+        let [mods, action] = binder.action('t')
+        Assert Equals(mods, '')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose t')
+        Assert Equals(mods, 'verbose ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose topleft t')
+        Assert Equals(mods, 'verbose topleft ')
+        Assert Equals(action.name, 'test')
+      End
+
+      It returns [{mods}, {action}] for an existing alias with mods
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        call binder.alias('t', 'silent test')
+        let [mods, action] = binder.action('t')
+        Assert Equals(mods, 'silent ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose t')
+        Assert Equals(mods, 'verbose silent ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose topleft t')
+        Assert Equals(mods, 'verbose topleft silent ')
+        Assert Equals(action.name, 'test')
+      End
+
+      It returns [{mods}, {action}] for an existing action which start from {expr}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        let [mods, action] = binder.action('tes')
+        Assert Equals(mods, '')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose tes')
+        Assert Equals(mods, 'verbose ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose topleft tes')
+        Assert Equals(mods, 'verbose topleft ')
+        Assert Equals(action.name, 'test')
+      End
+
+      It returns [{mods}, {action}] for an existing alias which start from {expr}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        call binder.alias('foo', 'test')
+        let [mods, action] = binder.action('fo')
+        Assert Equals(mods, '')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose fo')
+        Assert Equals(mods, 'verbose ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose topleft fo')
+        Assert Equals(mods, 'verbose topleft ')
+        Assert Equals(action.name, 'test')
+      End
+
+      It returns [{mods}, {action}] for an existing alias with mods which start from {expr}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        call binder.alias('foo', 'silent test')
+        let [mods, action] = binder.action('fo')
+        Assert Equals(mods, 'silent ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose fo')
+        Assert Equals(mods, 'verbose silent ')
+        Assert Equals(action.name, 'test')
+
+        let [mods, action] = binder.action('verbose topleft fo')
+        Assert Equals(mods, 'verbose topleft silent ')
+        Assert Equals(action.name, 'test')
+      End
+
+      It throws an exception when no action/alias is found for {expr}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        Throws /No corresponding action/ binder.action('fo')
+      End
+
+      It throws an exception when multiple action/alias are found for {expr}
+        let binder = Action.attach([])
+        call binder.define('test', Funcref)
+        call binder.alias('tes', 'test')
+        Throws /More than one/ binder.action('te')
+      End
+    End
+
+    Describe .call({expr} [, ...])
+      It filters {candidates} by {action.requirements} before call
+        let binder = Action.attach([])
+        call binder.define('test', Funcref, {
+              \ 'requirements': ['path'],
+              \})
+        call binder.alias('t', 'silent test')
+
+        let [mods, action] = binder.call('test', [
+              \ {'word': 'foo'},
+              \ {'word': 'bar'},
+              \ {'word': 'hoge', 'path': 1},
+              \])
+        Assert Equals(mods, '')
+        Assert Equals(action.name, 'test')
+        Assert Equals(b:_vital_action_test_called_with, [
+              \ [{'word': 'hoge', 'path': 1}],
+              \ {'mods': ''},
+              \])
+
+        let [mods, action] = binder.call('verbose test', [
+              \ {'word': 'foo'},
+              \ {'word': 'bar'},
+              \ {'word': 'hoge', 'path': 1},
+              \])
+        Assert Equals(mods, 'verbose ')
+        Assert Equals(action.name, 'test')
+        Assert Equals(b:_vital_action_test_called_with, [
+              \ [{'word': 'hoge', 'path': 1}],
+              \ {'mods': 'verbose '},
+              \])
+
+        let [mods, action] = binder.call('verbose t', [
+              \ {'word': 'foo'},
+              \ {'word': 'bar'},
+              \ {'word': 'hoge', 'path': 1},
+              \])
+        Assert Equals(mods, 'verbose silent ')
+        Assert Equals(action.name, 'test')
+        Assert Equals(b:_vital_action_test_called_with, [
+              \ [{'word': 'hoge', 'path': 1}],
+              \ {'mods': 'verbose silent '},
+              \])
+      End
+
+      Describe .call({expr} [, {fline} [, {lline}]])
+        It calls an action/alias of {expr} with a candidate of the current line and returns [{mods}, {action}]
+          let binder = Action.attach([
+                \ {'word': 'a'},
+                \ {'word': 'b'},
+                \ {'word': 'c'},
+                \])
+          call binder.define('test', Funcref)
+          call setline(1, ['a', 'b', 'c'])
+          call setpos('.', [0, 2, 1, 0])
+
+          let [mods, action] = binder.call('test')
+          Assert Equals(mods, '')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [{'word': 'b', '__lnum': 2}],
+                \ {'mods': ''},
+                \])
+        End
+
+        It calls an action/alias of {expr} with a candidate of {fline} and returns [{mods}, {action}]
+          let binder = Action.attach([
+                \ {'word': 'a'},
+                \ {'word': 'b'},
+                \ {'word': 'c'},
+                \])
+          call binder.define('test', Funcref)
+          call setline(1, ['a', 'b', 'c'])
+          call setpos('.', [0, 2, 1, 0])
+
+          let [mods, action] = binder.call('test', 3)
+          Assert Equals(mods, '')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [{'word': 'c', '__lnum': 3}],
+                \ {'mods': ''},
+                \])
+        End
+
+        It calls an action/alias of {expr} with candidates from {fline} to {lline} and returns [{mods}, {action}]
+          let binder = Action.attach([
+                \ {'word': 'a'},
+                \ {'word': 'b'},
+                \ {'word': 'c'},
+                \])
+          call binder.define('test', Funcref)
+          call setline(1, ['a', 'b', 'c'])
+          call setpos('.', [0, 2, 1, 0])
+
+          let [mods, action] = binder.call('test', 1, 3)
+          Assert Equals(mods, '')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [
+                \   {'word': 'a', '__lnum': 1},
+                \   {'word': 'b', '__lnum': 2},
+                \
+                \   {'word': 'c', '__lnum': 3},
+                \ ],
+                \ {'mods': ''},
+                \])
+        End
+
+        It calls an action/alias of {expr} with marked candidates and returns [{mods}, {action}]
+          " https://github.com/thinca/vim-themis/pull/46
+          Skip vim-themis currently does not support 'sign place' in tests. See #46 on vim-themis
+          let binder = Action.attach([
+                \ {'word': 'a'},
+                \ {'word': 'b'},
+                \ {'word': 'c'},
+                \], {
+                \ 'markable': 1,
+                \})
+          call binder.define('test', Funcref)
+          call setline(1, ['a', 'b', 'c'])
+          call setpos('.', [0, 2, 1, 0])
+          call binder.call('builtin:mark:set', 1)
+          call binder.call('builtin:mark:set', 3)
+
+          let [mods, action] = binder.call('test')
+          Assert Equals(mods, '')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [
+                \   {'word': 'a', '__lnum': 1},
+                \   {'word': 'c', '__lnum': 3},
+                \ ],
+                \ {'mods': ''},
+                \])
+        End
+      End
+
+      Describe .call({expr}, {candidates})
+        It calls an action/alias of {expr} with {candidates} and returns [{mods}, {action}]
+          let binder = Action.attach([])
+          call binder.define('test', Funcref)
+          call binder.alias('t', 'silent test')
+
+          let [mods, action] = binder.call('test', [
+                \ {'word': 'foo'},
+                \ {'word': 'bar'},
+                \])
+          Assert Equals(mods, '')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [{'word': 'foo'}, {'word': 'bar'}],
+                \ {'mods': ''},
+                \])
+
+          let [mods, action] = binder.call('verbose test', [
+                \ {'word': 'foo'},
+                \ {'word': 'bar'},
+                \])
+          Assert Equals(mods, 'verbose ')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [{'word': 'foo'}, {'word': 'bar'}],
+                \ {'mods': 'verbose '},
+                \])
+
+          let [mods, action] = binder.call('verbose t', [
+                \ {'word': 'foo'},
+                \ {'word': 'bar'},
+                \])
+          Assert Equals(mods, 'verbose silent ')
+          Assert Equals(action.name, 'test')
+          Assert Equals(b:_vital_action_test_called_with, [
+                \ [{'word': 'foo'}, {'word': 'bar'}],
+                \ {'mods': 'verbose silent '},
+                \])
+        End
+      End
     End
   End
-
 End


### PR DESCRIPTION
It close #41 

- `<mods>` is allowed in `builtin:choice` action. Users can perform actions like `verbose show`
- Actions in buffers for manipulation (currently `gina-status` and `gina-branch`) become markable. Users can mark candidates by `*` and all further actions are performed on the marked candidates

Please test behaviours and let me know if there are any unwilling points.