### PR TITLE
Add components for statusline/tabline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Missings
 The following features are planned but missing for now
 
 - Command completions
-- Component system for statusline/tabline like vim-gita has
 
 Pros.
 -------------------------------------------------------------------------------

--- a/autoload/gina/component/branch.vim
+++ b/autoload/gina/component/branch.vim
@@ -1,0 +1,86 @@
+scriptencoding utf-8
+
+let s:Git = vital#gina#import('Git')
+let s:Path = vital#gina#import('System.Filepath')
+let s:Store = vital#gina#import('System.Store')
+
+
+function! gina#component#branch#local() abort
+  let git = gina#core#get()
+  if empty(git)
+    return ''
+  endif
+  let slug = eval(s:Store.get_slug_expr())
+  let store = s:Store.of([
+        \ s:Git.resolve(git, 'HEAD'),
+        \ s:Git.resolve(git, 'config'),
+        \])
+  let branch = store.get(slug, '')
+  if !empty(branch)
+    return branch
+  endif
+  let result = gina#process#call(git, [
+        \ 'rev-parse',
+        \ '--abbrev-ref',
+        \ 'HEAD',
+        \])
+  if result.status
+    return ''
+  endif
+  let branch = get(result.stdout, 0)
+  call store.set(slug, branch)
+  return branch
+endfunction
+
+function! gina#component#branch#track() abort
+  let git = gina#core#get()
+  if empty(git)
+    return ''
+  endif
+  let slug = eval(s:Store.get_slug_expr())
+  let store = s:Store.of([
+        \ s:Git.resolve(git, 'HEAD'),
+        \ s:Git.resolve(git, 'config'),
+        \])
+  let branch = store.get(slug, '')
+  if !empty(branch)
+    return branch
+  endif
+  let result = gina#process#call(git, [
+        \ 'rev-parse',
+        \ '--abbrev-ref',
+        \ '--symbolic-full-name',
+        \ '@{upstream}',
+        \])
+  if result.status
+    return ''
+  endif
+  let branch = get(result.stdout, 0)
+  call store.set(slug, branch)
+  return branch
+endfunction
+
+function! gina#component#branch#preset(...) abort
+  let kind = get(a:000, 0, 'ascii')
+  return call('s:preset_' . kind, [])
+endfunction
+
+
+" Private --------------------------------------------------------------------
+function! s:preset_ascii() abort
+  let local = gina#component#branch#local()
+  let track = gina#component#branch#track()
+  if empty(track)
+    return local
+  endif
+  return printf('%s -> %s', local, track)
+endfunction
+
+function! s:preset_fancy() abort
+  let local = gina#component#branch#local()
+  let track = gina#component#branch#track()
+  if empty(track)
+    return local
+  endif
+  return printf('%s → %s', local, track)
+endfunction

--- a/autoload/gina/component/repo.vim
+++ b/autoload/gina/component/repo.vim
@@ -5,7 +5,15 @@ let s:Path = vital#gina#import('System.Filepath')
 let s:Store = vital#gina#import('System.Store')
 
 
-function! gina#component#branch#local() abort
+function! gina#component#repo#name() abort
+  let git = gina#core#get()
+  if empty(git)
+    return ''
+  endif
+  return fnamemodify(git.worktree, ':t')
+endfunction
+
+function! gina#component#repo#branch() abort
   let git = gina#core#get()
   if empty(git)
     return ''
@@ -32,7 +40,7 @@ function! gina#component#branch#local() abort
   return branch
 endfunction
 
-function! gina#component#branch#track() abort
+function! gina#component#repo#track() abort
   let git = gina#core#get()
   if empty(git)
     return ''
@@ -60,7 +68,7 @@ function! gina#component#branch#track() abort
   return branch
 endfunction
 
-function! gina#component#branch#preset(...) abort
+function! gina#component#repo#preset(...) abort
   let kind = get(a:000, 0, 'ascii')
   return call('s:preset_' . kind, [])
 endfunction
@@ -68,19 +76,21 @@ endfunction
 
 " Private --------------------------------------------------------------------
 function! s:preset_ascii() abort
-  let local = gina#component#branch#local()
-  let track = gina#component#branch#track()
+  let name = gina#component#repo#name()
+  let branch = gina#component#repo#branch()
+  let track = gina#component#repo#track()
   if empty(track)
-    return local
+    return printf('%s [%s]', name, branch)
   endif
-  return printf('%s -> %s', local, track)
+  return printf('%s [%s -> %s]', name, branch, track)
 endfunction
 
 function! s:preset_fancy() abort
-  let local = gina#component#branch#local()
-  let track = gina#component#branch#track()
+  let name = gina#component#repo#name()
+  let branch = gina#component#repo#branch()
+  let track = gina#component#repo#track()
   if empty(track)
-    return local
+    return printf('%s [%s]', name, branch)
   endif
-  return printf('%s → %s', local, track)
+  return printf('%s [%s → %s]', name, branch, track)
 endfunction

--- a/autoload/gina/component/status.vim
+++ b/autoload/gina/component/status.vim
@@ -92,9 +92,9 @@ function! s:preset_ascii() abort
   let staged = gina#component#status#staged()
   let unstaged = gina#component#status#unstaged()
   let conflicted = gina#component#status#conflicted()
-  let staged = empty(staged) ? '' : ('+' . staged)
-  let unstaged = empty(unstaged) ? '' : ('-' . unstaged)
-  let conflicted = empty(conflicted) ? '' : ('"' . conflicted)
+  let staged = empty(staged) ? '' : ('<' . staged)
+  let unstaged = empty(unstaged) ? '' : ('>' . unstaged)
+  let conflicted = empty(conflicted) ? '' : ('x' . conflicted)
   return join([staged, unstaged, conflicted])
 endfunction
 
@@ -102,9 +102,9 @@ function! s:preset_fancy() abort
   let staged = gina#component#status#staged()
   let unstaged = gina#component#status#unstaged()
   let conflicted = gina#component#status#conflicted()
-  let staged = empty(staged) ? '' : ('⁺' . staged)
-  let unstaged = empty(unstaged) ? '' : ('⁻' . unstaged)
-  let conflicted = empty(conflicted) ? '' : ('‶' . conflicted)
+  let staged = empty(staged) ? '' : ('«' . staged)
+  let unstaged = empty(unstaged) ? '' : ('»' . unstaged)
+  let conflicted = empty(conflicted) ? '' : ('×' . conflicted)
   return join([staged, unstaged, conflicted])
 endfunction
 

--- a/autoload/gina/component/traffic.vim
+++ b/autoload/gina/component/traffic.vim
@@ -1,0 +1,111 @@
+scriptencoding utf-8
+
+let s:Git = vital#gina#import('Git')
+let s:Path = vital#gina#import('System.Filepath')
+let s:Store = vital#gina#import('System.Store')
+
+
+function! gina#component#traffic#ahead() abort
+  let git = gina#core#get()
+  if empty(git)
+    return ''
+  endif
+  let slug = eval(s:Store.get_slug_expr())
+  let ref = get(s:Git.ref(git, 'HEAD'), 'path', 'HEAD')
+  let track = s:get_tracking_ref(git)
+  let store = s:Store.of([
+        \ s:Git.resolve(git, 'index'),
+        \ s:Git.resolve(git, ref),
+        \ s:Git.resolve(git, track),
+        \])
+  let ahead = store.get(slug, '')
+  if !empty(ahead)
+    return ahead
+  endif
+  let result = gina#process#call(git, [
+        \ 'log',
+        \ '--oneline',
+        \ '@{upstream}..',
+        \])
+  if result.status
+    return ''
+  endif
+  let ahead = len(filter(result.stdout, '!empty(v:val)')) . ''
+  call store.set(slug, ahead)
+  return ahead
+endfunction
+
+function! gina#component#traffic#behind() abort
+  let git = gina#core#get()
+  if empty(git)
+    return ''
+  endif
+  let slug = eval(s:Store.get_slug_expr())
+  let ref = get(s:Git.ref(git, 'HEAD'), 'path', 'HEAD')
+  let track = s:get_tracking_ref(git)
+  let store = s:Store.of([
+        \ s:Git.resolve(git, 'index'),
+        \ s:Git.resolve(git, ref),
+        \ s:Git.resolve(git, track),
+        \])
+  let behind = store.get(slug, '')
+  if !empty(behind)
+    return behind
+  endif
+  let result = gina#process#call(git, [
+        \ 'log',
+        \ '--oneline',
+        \ '..@{upstream}',
+        \])
+  if result.status
+    return ''
+  endif
+  let behind = len(filter(result.stdout, '!empty(v:val)')) . ''
+  call store.set(slug, behind)
+  return behind
+endfunction
+
+function! gina#component#traffic#preset(...) abort
+  let kind = get(a:000, 0, 'ascii')
+  return call('s:preset_' . kind, [])
+endfunction
+
+" Private --------------------------------------------------------------------
+function! s:get_tracking_ref(git) abort
+  let slug = eval(s:Store.get_slug_expr())
+  let store = s:Store.of([
+        \ s:Git.resolve(a:git, 'HEAD'),
+        \ s:Git.resolve(a:git, 'config'),
+        \])
+  let ref = store.get(slug, '')
+  if !empty(ref)
+    return ref
+  endif
+  let result = gina#process#call(a:git, [
+        \ 'rev-parse',
+        \ '--symbolic-full-name',
+        \ '@{upstream}',
+        \])
+  if result.status
+    return ''
+  endif
+  let ref = get(result.stdout, 0)
+  call store.set(slug, ref)
+  return ref
+endfunction
+
+function! s:preset_ascii() abort
+  let ahead = gina#component#traffic#ahead()
+  let behind = gina#component#traffic#behind()
+  let ahead = empty(ahead) ? '' : ('^' . ahead)
+  let behind = empty(behind) ? '' : ('v' . behind)
+  return join([ahead, behind])
+endfunction
+
+function! s:preset_fancy() abort
+  let ahead = gina#component#traffic#ahead()
+  let behind = gina#component#traffic#behind()
+  let ahead = empty(ahead) ? '' : ('↑' . ahead)
+  let behind = empty(behind) ? '' : ('↓' . behind)
+  return join([ahead, behind])
+endfunction

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -14,6 +14,7 @@ INTRODUCTION			|gina-introduction|
 USAGE				|gina-usage|
   COMMAND			  |gina-usage-command|
   ACTION			  |gina-usage-action|
+  COMPONENT			  |gina-usage-component|
 CUSTOM				|gina-custom|
   ACTION			  |gina-custom-action|
   MAPPING			  |gina-custom-mapping|
@@ -250,6 +251,66 @@ To customize the mark, users can use the followings
 
 |g:gina#action#mark_sign_text|
 |hl-GinaActionMarkSelected|
+
+-----------------------------------------------------------------------------
+COMPONENT					*gina-usage-component*
+
+Gina provides component functions which return a cached string for
+|statusline| and/or |tabline|.
+
+For example, if users want to show an information about the git repository, 
+they can use the following code to show it on a |statusline|.
+>
+	set statusline=...%{gina#component#repo#preset()}...
+<
+Or if users prefer to use non ASCII characters, specify "fancy" to the
+first attribute like:
+>
+	set statusline=...%{gina#component#repo#preset('fancy')}...
+<
+Gina provides the following preset component functions
+
+	function				description~
+	|gina#component#repo#preset()|		A general information.
+	|gina#component#status#preset()|	A current git status.
+	|gina#component#traffic#preset()|	A traffic information.
+
+If users want to control the looks of the component, they can use a raw
+component functions like
+>
+	set statusline=...%{MyGitStatus()}...
+
+	function MyGitStatus() abort
+	  let staged = gina#component#status#staged()
+	  let unstaged = gina#component#status#unstaged()
+	  let conflicted = gina#component#status#conflicted()
+	  return printf(
+	        \ 's: %s, u: %s, c: %s',
+	        \ staged,
+	        \ unstaged,
+	        \ conflicted,
+	        \)
+	endfunction
+<
+Gina provides the following raw component functions
+
+	function				description~
+	|gina#component#repo#name()|		A name of the current git
+						repository. Namely, this is a
+						directory name of the git
+						repository top.
+	|gina#component#repo#branch()|		A name of the current branch.
+	|gina#component#repo#track()|		A name of the current tracking
+						branch.
+	|gina#component#status#staged()|	A number of staged files.
+	|gina#component#status#unstaged()|	A number of unstaged files.
+	|gina#component#status#conflicted()|	A number of conflicted files.
+	|gina#component#traffic#ahead()|	A number of commits ahead of
+						the tracking branch.
+	|gina#component#traffic#behind()|	A number of commits behind of
+						the tracking branch.
+
+Note that the values are cached to improve the performance.
 
 
 =============================================================================
@@ -1673,6 +1734,95 @@ gina#custom#command#option({scheme}, {option} [, {value}])
 	See also~
 	|gina-custom-command|
 	|gina-custom-command-alias|
+
+					*gina#component#repo#preset()*
+gina#component#repo#preset([{kind}])
+	Return a cached repository information which includes a repository
+	name, a current branch name, and a tracking branch name.
+>
+	" With a tracking branch
+	echo gina#component#repo#preset()
+	" -> 'gina.vim [master -> origin/master]'
+
+	echo gina#component#repo#preset('fancy')
+	" -> 'gina.vim [master → origin/master]'
+
+	" Without a tracking branch
+	echo gina#component#repo#preset()
+	" -> 'gina.vim [master]'
+
+	echo gina#component#repo#preset('fancy')
+	" -> 'gina.vim [master]'
+<
+	It uses the following raw component functions internally.
+	|gina#component#repo#name()|
+	|gina#component#repo#branch()|
+	|gina#component#repo#track()|
+ 
+					*gina#component#repo#name()*
+gina#component#repo#name()
+	Return a name of the current repository, namely it is a directory name
+	of the repository.
+
+					*gina#component#repo#branch()*
+gina#component#repo#branch()
+	Return a cached name of the current branch.
+
+					*gina#component#repo#track()*
+gina#component#repo#track()
+	Return a cached name of the tracking branch of the current branch.
+
+					*gina#component#status#preset()*
+gina#component#status#preset([{kind}])
+	Return a cached repository status which includes a number of the
+	staged, unstaged, and conflicted files.
+>
+	echo gina#component#status#preset()
+	" -> '<2 >4 x3'
+
+	echo gina#component#status#preset('fancy')
+	" -> '«2 »4 ×3'
+<
+	It uses the following raw component functions internally.
+	|gina#component#status#staged()|
+	|gina#component#status#unstaged()|
+	|gina#component#status#conflicted()|
+
+					*gina#component#status#staged()*
+gina#component#status#staged()
+	Return a cached number of staged files.
+
+					*gina#component#status#unstaged()*
+gina#component#status#unstaged()
+	Return a cached number of unstaged files.
+
+					*gina#component#status#conflicted()*
+gina#component#status#conflicted()
+	Return a cached number of conflicted files.
+
+					*gina#component#traffic#preset()*
+gina#component#traffic#preset([{kind}])
+	Return a cached traffic information between a current branch and a
+	current tracking branch.
+>
+	echo gina#component#traffic#preset()
+	" -> '^2 v4'
+
+	echo gina#component#traffic#preset('fancy')
+	" -> '↑2 ↓4'
+<
+	It uses the following raw component functions internally.
+	|gina#component#traffic#ahead()|
+	|gina#component#traffic#behind()|
+
+					*gina#component#traffic#ahead()*
+gina#component#traffic#ahead()
+	Return a cached number of commits ahead of the current tracking
+	branch.
+					*gina#component#traffic#behind()*
+gina#component#traffic#behind()
+	Return a cached number of commits behind of the current tracking
+	branch.
 
 					*gina#custom#mapping#map()*
 					*gina#custom#mapping#nmap()*


### PR DESCRIPTION
## Looks
With lightline.vim, it looks like

![screenshot 2017-03-16 13 51 19](https://cloud.githubusercontent.com/assets/546312/23982283/d47b0752-0a4f-11e7-9b48-593234cde71a.png)

With `gina#component#XXXXX#preset('fancy')`.

Note that you don't need lightline.vim. I use it because I could not be bothered 😆 

## Usage

```
# For users who use ASCII only font
echo gina#component#branch#preset()
echo gina#component#status#preset()
echo gina#component#traffic#preset()

# For users who use Non-ASCII available font
echo gina#component#branch#preset('fancy')
echo gina#component#status#preset('fancy')
echo gina#component#traffic#preset('fancy')

# For users who want to control the looks
echo gina#component#branch#local()
echo gina#component#branch#track()

echo gina#component#status#staged()
echo gina#component#status#unstaged()
echo gina#component#status#conflicted()

echo gina#component#traffic#ahead()
echo gina#component#traffic#behind()
```

Any suggestions or comments?

## Known issues

- Untracked files and Ignored files are not shown in status
    - While there is no way to detect adding untracked files/ignored files, this feature will not be implemented
- <del>status is not updated when tracked files are modified</del> (Fixed)