### PR TITLE
Add mapping to exit entire blame (#78)

### DIFF
--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -191,8 +191,15 @@ endfunction
 
 function! s:exit_from_entire_blame() abort
   let bufinfo = s:get_blame_buffer_info()
-  execute 'silent! bwipeout ' bufinfo.alternative_name
-  execute 'silent! bwipeout ' bufinfo.current_name
+  let original_buffer = gina#core#buffer#param(bufname('%'), 'path')
+  try
+    execute printf('%dclose', bufwinnr(bufinfo.alternative_name))
+  catch /^Vim\%((\a\+)\)\=:E444/
+    " E444: Cannot close last window may thrown but ignore that
+    " Vim.Buffer.Group should NOT close the last window so ignore
+    " this exception silently.
+  endtry
+  execute 'buffer ' original_buffer
 endfunction
 
 function! s:redraw_content() abort

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -60,6 +60,7 @@ function! s:call(range, args, mods) abort
     autocmd! * <buffer>
     autocmd WinLeave <buffer> call s:WinLeave()
     autocmd WinEnter <buffer> call s:WinEnter()
+    autocmd QuitPre  <buffer> call s:QuitPre()
   augroup END
   nnoremap <buffer><silent> <Plug>(gina-blame-exit)
         \ :<C-u>call <SID>exit_from_entire_blame()<CR>
@@ -137,6 +138,7 @@ function! s:init(args) abort
     autocmd VimResized <buffer> call s:redraw_content_if_necessary()
     autocmd WinLeave <buffer> call s:WinLeave()
     autocmd WinEnter <buffer> call s:WinEnter()
+    autocmd QuitPre <buffer> call s:QuitPre()
     autocmd BufReadCmd <buffer>
           \ call gina#core#exception#call(function('s:BufReadCmd'), [])
   augroup END
@@ -155,6 +157,10 @@ function! s:WinEnter() abort
     unlet b:gina_syncbind_line
   endif
   syncbind
+endfunction
+
+function! s:QuitPre() abort
+  call s:exit_from_entire_blame()
 endfunction
 
 function! s:BufReadCmd() abort

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -143,9 +143,9 @@ function! s:init(args) abort
 endfunction
 
 function! s:WinLeave() abort
-  let buffers = s:blame_buffer_names()
-  if bufwinnr(buffers.alternate) > 0
-    call setbufvar(buffers.alternate, 'gina_syncbind_line', line('.'))
+  let bufinfo = s:get_blame_buffer_info()
+  if bufwinnr(bufinfo.alternative_name) > 0
+    call setbufvar(bufinfo.alternative_name, 'gina_syncbind_line', line('.'))
   endif
 endfunction
 
@@ -177,7 +177,7 @@ function! s:BufReadCmd() abort
   setlocal filetype=gina-blame
 endfunction
 
-function! s:blame_buffer_names() abort
+function! s:get_blame_buffer_info() abort
   let bufname = bufname('%')
   let scheme = gina#core#buffer#param(bufname, 'scheme')
   let alternate = substitute(
@@ -186,13 +186,13 @@ function! s:blame_buffer_names() abort
         \ ':' . (scheme ==# 'blame' ? 'show' : 'blame'),
         \ ''
         \)
-  return {'current': bufname, 'alternate': alternate}
+  return {'current_name': bufname, 'alternative_name': alternate}
 endfunction
 
 function! s:exit_from_entire_blame() abort
-  let buffers = s:blame_buffer_names()
-  exe 'silent! bwipeout '.buffers.alternate
-  exe 'silent! bwipeout '.buffers.current
+  let bufinfo = s:get_blame_buffer_info()
+  execute 'silent! bwipeout ' bufinfo.alternative_name
+  execute 'silent! bwipeout ' bufinfo.current_name
 endfunction
 
 function! s:redraw_content() abort

--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -191,8 +191,8 @@ endfunction
 
 function! s:exit_from_entire_blame() abort
   let buffers = s:blame_buffer_names()
-  exe 'silent bwipeout '.buffers.alternate
-  exe 'silent bwipeout '.buffers.current
+  exe 'silent! bwipeout '.buffers.alternate
+  exe 'silent! bwipeout '.buffers.current
 endfunction
 
 function! s:redraw_content() abort


### PR DESCRIPTION
It's not binded to anything yet. To try it out, press `q` in any of the `Gina blame` windows:
```
map q <Plug>(gina-blame-exit)
```