### PR TITLE
Don't confirm on `:q` without commitmsg

### DIFF
--- a/autoload/gina/command/commit.vim
+++ b/autoload/gina/command/commit.vim
@@ -131,11 +131,15 @@ function! s:WinLeave() abort
             \ [git, args]
             \)
     else
-      " User execute 'q' so confirm
-      call gina#core#exception#call(
-            \ function('s:commit_commitmsg_confirm'),
-            \ [git, args]
-            \)
+      " User execute 'q' so confirm if commit message is written
+      if !empty(s:get_cached_commitmsg(git, args))
+        call gina#core#exception#call(
+              \ function('s:commit_commitmsg_confirm'),
+              \ [git, args]
+              \)
+      else
+        redraw | echo ''
+      endif
     endif
   endif
 endfunction


### PR DESCRIPTION
If the user exists with `:q` from commit buffer, but there never made commit message, then do not confirm, just close the window.