### PR TITLE
Add rbtnn/vim-gitdiff like feature

### DIFF
--- a/autoload/gina/command/commit.vim
+++ b/autoload/gina/command/commit.vim
@@ -88,6 +88,18 @@ function! s:init(args) abort
 
   nnoremap <silent><buffer> <Plug>(gina-commit-amend)
         \ :<C-u>call <SID>toggle_amend()<CR>
+
+  if a:args.get('-v|--verbose')
+    nnoremap <buffer><silent> <Plug>(gina-diff-jump)
+          \ :<C-u>call gina#core#diff#jump()<CR>
+    nnoremap <buffer><silent> <Plug>(gina-diff-jump-split)
+          \ :<C-u>call gina#core#diff#jump('split')<CR>
+    nnoremap <buffer><silent> <Plug>(gina-diff-jump-vsplit)
+          \ :<C-u>call gina#core#diff#jump('vsplit')<CR>
+    if g:gina#command#commit#use_default_mappings
+      nmap <buffer> <CR> <Plug>(gina-diff-jump)
+    endif
+  endif
 endfunction
 
 function! s:BufReadCmd() abort

--- a/autoload/gina/command/diff.vim
+++ b/autoload/gina/command/diff.vim
@@ -68,6 +68,16 @@ function! s:init(args) abort
     autocmd BufWinEnter <buffer> setlocal buflisted
     autocmd BufWinLeave <buffer> setlocal nobuflisted
   augroup END
+
+  nnoremap <buffer><silent> <Plug>(gina-diff-jump)
+        \ :<C-u>call gina#core#diff#jump()<CR>
+  nnoremap <buffer><silent> <Plug>(gina-diff-jump-split)
+        \ :<C-u>call gina#core#diff#jump('split')<CR>
+  nnoremap <buffer><silent> <Plug>(gina-diff-jump-vsplit)
+        \ :<C-u>call gina#core#diff#jump('vsplit')<CR>
+  if g:gina#command#diff#use_default_mappings
+    nmap <buffer> <CR> <Plug>(gina-diff-jump)
+  endif
 endfunction
 
 function! s:BufReadCmd() abort
@@ -91,3 +101,9 @@ function! s:writer.on_stop() abort
   call self.super(s:writer, 'on_stop')
   call gina#core#emitter#emit('command:called', s:SCHEME)
 endfunction
+
+
+" Config ---------------------------------------------------------------------
+call gina#config(expand('<sfile>'), {
+      \ 'use_default_mappings': 1,
+      \})

--- a/autoload/gina/core/diff.vim
+++ b/autoload/gina/core/diff.vim
@@ -1,0 +1,102 @@
+function! s:find_path_and_lnum(git) abort
+  if getline('.') =~# '^-'
+    return s:find_path_and_lnum_lhs(a:git)
+  elseif getline('.') =~# '^[ +]'
+    return s:find_path_and_lnum_rhs(a:git)
+  else
+    return v:null
+  endif
+endfunction
+
+function! s:find_path_and_lnum_lhs(git) abort
+  let lnum = search('^@@', 'bnW')
+  let path = matchstr(
+        \ getline(search('^--- a/', 'bnW')),
+        \ '^--- a/\zs.*$'
+        \)
+  let m = matchlist(
+        \ getline(lnum),
+        \ '^@@ -\(\d\+\)\%(,\(\d\+\)\)\? +\(\d\+\),\(\d\+\) @@\(.*\)$'
+        \)
+  if empty(m)
+    return v:null
+  endif
+  let n = len(filter(
+        \ map(range(lnum, line('.')), 'getline(v:val)'),
+        \ 'v:val !~# ''^+''')
+        \)
+  return {'path': path, 'lnum': m[1] + n - 2, 'side': 0}
+endfunction
+
+function! s:find_path_and_lnum_rhs(git) abort
+  if getline('.') !~# '^[ -+]'
+    return v:null
+  endif
+  let lnum = search('^@@', 'bnW')
+  let path = matchstr(
+        \ getline(search('^+++ b/', 'bnW')),
+        \ '^+++ b/\zs.*$'
+        \)
+  let m = matchlist(
+        \ getline(lnum),
+        \ '^@@ -\(\d\+\)\%(,\(\d\+\)\)\? +\(\d\+\),\(\d\+\) @@\(.*\)$'
+        \)
+  if empty(m)
+    return v:null
+  endif
+  let n = len(filter(
+        \ map(range(lnum, line('.')), 'getline(v:val)'),
+        \ 'v:val !~# ''^-''')
+        \)
+  return {'path': path, 'lnum': m[3] + n - 2, 'side': 1}
+endfunction
+
+function! s:jump(opener) abort
+  let git = gina#core#get_or_fail()
+  let pathinfo = s:find_path_and_lnum(git)
+  if pathinfo is v:null
+    return 0
+  endif
+
+  let rev = gina#core#buffer#param(bufname('%'), 'rev')
+  let rev = gina#core#treeish#split(rev)[pathinfo.side]
+  if empty(rev) && pathinfo.side == 1
+    call gina#core#console#debug(printf(
+          \ 'Gina edit --line=%d --opener=%s %s',
+          \ pathinfo.lnum,
+          \ a:opener,
+          \ pathinfo.path,
+          \))
+    execute printf(
+          \ 'Gina edit --line=%d --opener=%s %s',
+          \ pathinfo.lnum,
+          \ a:opener,
+          \ pathinfo.path,
+          \)
+  else
+    call gina#core#console#debug(printf(
+          \ 'Gina show --line=%d --opener=%s %s:%s',
+          \ pathinfo.lnum,
+          \ a:opener,
+          \ rev,
+          \ pathinfo.path,
+          \))
+    execute printf(
+          \ 'Gina show --line=%d --opener=%s %s:%s',
+          \ pathinfo.lnum,
+          \ a:opener,
+          \ rev,
+          \ pathinfo.path,
+          \)
+  endif
+  return 1
+endfunction
+
+function! gina#core#diff#jump(...) abort
+  let opener = a:0 ? a:1 : ''
+  let opener = empty(opener) ? 'edit' : opener
+  return gina#core#exception#call(
+        \ function('s:jump'),
+        \ [opener],
+        \)
+endfunction

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -894,10 +894,22 @@ Note that no actions are available on this buffer.
 The following <Plug> mapping is available on this buffer
 	
 	<Plug>(gina-commit-amend)	Toggle "--amend" option
+	<Plug>(gina-diff-jump)		Jump to a corresponding file with a
+					corresponding line number.
+					If jumps to the source file when the
+					cursor is on removed line (the line
+					starts from '-') or destination file
+					when the cursor is on non modified or
+					added line (the line starts from ' '
+					or '+').
+					Works only on diff content visibled
+					when '-v' or '--verbose' option is
+					specified.
 
 And the following default keymapping is defined
 	
 	!		Switch --amend option
+	<Return>	Jump to a corresponding file
 
 Users can disable the default mappings by
 
@@ -909,7 +921,27 @@ DIFF						*gina-buffer-diff*
 					'filetype':	diff
 
 This is a "file-like" buffer which is shown by |:Gina-diff| command.
-Note that no actions or default mappings are available on this buffer.
+
+The following <Plug> mapping is available on this buffer
+	
+	<Plug>(gina-diff-jump)		Jump to a corresponding file with a
+					corresponding line number.
+					If jumps to the source file when the
+					cursor is on removed line (the line
+					starts from '-') or destination file
+					when the cursor is on non modified or
+					added line (the line starts from ' '
+					or '+')
+
+And the following default keymapping is defined
+	
+	<Return>	Jump to a corresponding file
+
+Users can disable the default mappings by
+
+	|g:gina#command#diff#use_default_mappings|
+
+Note that no actions are available on this buffer.
 
 -----------------------------------------------------------------------------
 GREP						*gina-buffer-grep*


### PR DESCRIPTION
Ref: https://github.com/rbtnn/vim-gitdiff

When user hit Return on diff content (include git commit -v), open a corresponding
line on the corresponding buffer.

The following points are improved from the origin

- Support non worktree content
- Support lines which was removed

Thanks to @rbtnn 