### PR TITLE
Hotfix #133

### DIFF
--- a/autoload/gina/action/index.vim
+++ b/autoload/gina/action/index.vim
@@ -313,7 +313,14 @@ function! s:on_discard(candidates, options) abort dict
   for candidate in delete_candidates
     let abspath = s:Path.realpath(gina#core#repo#abspath(git, candidate.path))
     if isdirectory(abspath)
-      call s:File.rmdir(abspath, 'r')
+      if g:gina#action#index#discard_directories
+        call s:File.rmdir(abspath, 'r')
+      else
+        call gina#core#console#info(printf(
+              \ '"%s" is directory. While g:gina#action#index#discard_directories is not set, it is not removed.',
+              \ candidate.path,
+              \))
+      endif
     elseif filewritable(abspath)
       call delete(abspath)
     endif
@@ -323,3 +330,9 @@ function! s:on_discard(candidates, options) abort dict
     call gina#core#emitter#emit('modified:delay')
   endif
 endfunction
+
+
+" Config ---------------------------------------------------------------------
+call gina#config(expand('<sfile>'), {
+      \ 'discard_directories': 0,
+      \})

--- a/autoload/gina/core/path.vim
+++ b/autoload/gina/core/path.vim
@@ -9,14 +9,14 @@ if s:is_windows
     return s:Path.unixpath(s:expand(s:realpath(a:expr)))
   endfunction
 
-  function! gina#core#path#abspath(expr, ...) abort
-    let path = s:realpath(s:expand(s:realpath(a:expr)))
+  function! gina#core#path#abspath(path, ...) abort
+    let path = s:realpath(a:path)
     return s:Path.unixpath(call('s:abspath', [path] + a:000))
   endfunction
 
-  function! gina#core#path#relpath(expr, ...) abort
-    let path = s:realpath(s:expand(s:realpath(a:expr)))
-    return s:Path.unixpath(call('s:path', [path] + a:000))
+  function! gina#core#path#relpath(path, ...) abort
+    let path = s:realpath(a:path)
+    return s:Path.unixpath(call('s:relpath', [path] + a:000))
   endfunction
 
   function! s:realpath(path) abort
@@ -30,14 +30,12 @@ else
     return s:expand(a:expr)
   endfunction
 
-  function! gina#core#path#abspath(expr, ...) abort
-    let path = s:expand(a:expr)
-    return call('s:abspath', [path] + a:000)
+  function! gina#core#path#abspath(path, ...) abort
+    return call('s:abspath', [a:path] + a:000)
   endfunction
 
-  function! gina#core#path#relpath(expr, ...) abort
-    let path = s:expand(a:expr)
-    return call('s:path', [path] + a:000)
+  function! gina#core#path#relpath(path, ...) abort
+    return call('s:relpath', [a:path] + a:000)
   endfunction
 endif
 
@@ -66,7 +64,7 @@ function! s:abspath(path, ...) abort
   return s:Path.join(root, a:path)
 endfunction
 
-function! s:path(path, ...) abort
+function! s:relpath(path, ...) abort
   if s:Path.is_relative(a:path) || a:path[0] ==# ':'
     return a:path
   endif

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -1973,6 +1973,12 @@ gina#custom#mapping#imap({scheme}, {lhs}, {rhs} [, {options}])
 -----------------------------------------------------------------------------
 VARIABLES					*gina-variables*
 
+		*g:gina#action#index#discard_directories*
+g:gina#action#index#discard_directories
+	A safe-net for index:discard action.
+	If the value is not 1, gina ignore any directory candidates.
+	Default: 0
+
 		*g:gina#action#mark_sign_text*
 g:gina#action#mark_sign_text
 	One or two characters used for a mark |sign|.
@@ -2407,7 +2413,9 @@ index:discard
 index:discard:force (hidden)
 	Discard changes on a working tree.
 	If the file is tracked, the content is overwritten via the content in
-	HEAD. If the file is untracked, the file is removed
+	HEAD. If the file is untracked, the file is removed.
+	See |g:gina#action#index#discard_directories| if you would like to
+	discard directories as well.
 
 					*gina-actions-ls*
 ls

--- a/test/gina/action/index.vimspec
+++ b/test/gina/action/index.vimspec
@@ -1,0 +1,82 @@
+Describe gina#action#index
+  Before all
+    let Path = vital#gina#import('System.Filepath')
+    let slit = Slit(tempname(), 1)
+    call slit.write('A/foo.txt', ['foo'])
+    call slit.write('B/foo.txt', ['foo'])
+    call slit.write('C/foo.txt', ['foo'])
+    call slit.write('D/foo.txt', ['foo'])
+    call slit.write('E/foo.txt', ['foo'])
+    call slit.write('F/foo.txt', ['foo'])
+    call slit.write('G/<Plug>_', ['foo'])
+
+    call slit.execute('add %s', slit.path('A/foo.txt'))
+    call slit.execute('commit --quiet -m "First"')
+    call slit.execute('add %s', slit.path('B/foo.txt'))
+    call slit.execute('commit --quiet -m "Second"')
+    call slit.execute('add %s', slit.path('C/foo.txt'))
+    call slit.execute('commit --quiet -m "Thrid"')
+    " Edit C/foo.txt
+    call slit.write('C/foo.txt', ['foobar'])
+  End
+
+  After all
+    %bwipeout!
+  End
+
+  Before
+    %bwipeout!
+    execute 'edit' fnameescape(slit.worktree)
+    call gina#action#attach([])
+    call gina#action#include('index')
+  End
+
+  Describe 'discard' action
+    It checkouts and overwrite the modification on tracked files
+      Assert Equals(readfile(slit.path('C/foo.txt')), ['foobar'])
+      call gina#action#call('index:discard:force', [
+            \ { 'path': slit.path('C/foo.txt'), 'sign': ' M' },
+            \])
+      call gina#process#wait()
+      Assert Equals(readfile(slit.path('C/foo.txt')), ['foo'])
+    End
+
+    It deletes untracked files
+      Assert True(filereadable(slit.path('D/foo.txt')))
+      call gina#action#call('index:discard:force', [
+            \ { 'path': slit.path('D/foo.txt'), 'sign': '!!' },
+            \])
+      Assert False(filereadable(slit.path('D/foo.txt')))
+    End
+
+    It cannot delete directories for safety
+      Assert True(isdirectory(slit.path('E')))
+      call gina#action#call('index:discard:force', [
+            \ { 'path': slit.path('E'), 'sign': '!!' },
+            \])
+      Assert True(isdirectory(slit.path('E')))
+    End
+
+    It can delete directories if g:gina#action#index#discard_directories = 1
+      let g:gina#action#index#discard_directories = 1
+      Assert True(isdirectory(slit.path('F')))
+      call gina#action#call('index:discard:force', [
+            \ { 'path': slit.path('F'), 'sign': '!!' },
+            \])
+      Assert False(isdirectory(slit.path('F')))
+      unlet g:gina#action#index#discard_directories
+    End
+
+    It can handle <Plug>_ correctly (Issue #133)
+      Assert True(filereadable(slit.path('G/<Plug>_')))
+      call gina#action#call('index:discard:force', [
+            \ { 'path': slit.path('G/<Plug>_'), 'sign': '!!' },
+            \])
+      Assert False(filereadable(slit.path('G/<Plug>_')))
+      Assert True(filereadable(slit.path('A/foo.txt')))
+      Assert True(filereadable(slit.path('B/foo.txt')))
+      Assert True(filereadable(slit.path('C/foo.txt')))
+    End
+  End
+End
+

--- a/test/gina/core/path.vimspec
+++ b/test/gina/core/path.vimspec
@@ -66,12 +66,22 @@ Describe gina#core#path
       let expr = Path.realpath(':/foo/bar.txt')
       Assert Equals(gina#core#path#abspath(expr), ':/foo/bar.txt')
     End
+
+    It does not expand <Plug>_
+      let expect = Path.realpath(getcwd() . '/<Plug>_')
+      Assert Equals(gina#core#path#abspath('<Plug>_'), expect)
+    End
   End
 
   Describe #relpath({expr} [, {root}])
     It returns a Unix-like path of {expr} when {expr} starts from ':'
       let expr = Path.realpath(':/foo/bar.txt')
       Assert Equals(gina#core#path#relpath(expr), ':/foo/bar.txt')
+    End
+
+    It does not expand <Plug>_
+      let expect = Path.realpath('<Plug>_')
+      Assert Equals(gina#core#path#relpath('<Plug>_'), expect)
     End
   End
 End


### PR DESCRIPTION
1. Do not use 'expand()' in abspath/relpath to prevent unwilling expand.
2. Add g:gina#action#index#discard_directories for safe-net
3. Add tests

Fix #133