### PR TITLE
Add a foldmethod to gina-diff

### DIFF
--- a/autoload/gina/command/diff.vim
+++ b/autoload/gina/command/diff.vim
@@ -382,7 +382,7 @@ function! s:BufReadCmd() abort
   let pipe = gina#process#pipe#stream(s:writer)
   call gina#core#buffer#assign_cmdarg()
   call gina#process#open(git, args, pipe)
-  setlocal filetype=diff
+  setlocal filetype=gina-diff
 endfunction
 
 

--- a/autoload/gina/foldmethod.vim
+++ b/autoload/gina/foldmethod.vim
@@ -1,0 +1,6 @@
+function! gina#foldmethod#diff(lnum)
+  return getline(a:lnum)     =~# '^@@'   ? '>1'
+  \    : getline(a:lnum + 1) =~# '^diff' ? '<1'
+  \    : getline(a:lnum + 1) =~# '^@@'   ? '<1'
+  \                                      : '='
+endfunction

--- a/ftplugin/gina-diff.vim
+++ b/ftplugin/gina-diff.vim
@@ -1,0 +1,3 @@
+setlocal foldmethod=expr
+setlocal foldexpr=gina#foldmethod#diff(v:lnum)
+setlocal nofoldenable

--- a/syntax/gina-diff.vim
+++ b/syntax/gina-diff.vim
@@ -1,0 +1,8 @@
+if exists('b:current_syntax')
+  finish
+endif
+
+" Use Vim's builtin syntax for diff
+runtime! syntax/diff.vim
+
+let b:current_syntax = 'gina-diff'


### PR DESCRIPTION
The foldmethod 'gina#foldmethod#diff' is disabled by default.
Also, it is enabled when a user inputs 'zc'.

![example](https://gyazo.com/f50051daef26ce6f60bc45ac7a6b797b.gif)