### PR TITLE
Support leading # in Gina status

### DIFF
--- a/autoload/gina/command/status.vim
+++ b/autoload/gina/command/status.vim
@@ -169,11 +169,11 @@ function! s:parse_record_normal(record, residual) abort
         \ 'deleted by them': 'UD',
         \}
   let record = s:String.remove_ansi_sequences(a:record)
-  if record !~# '^\t'
+  if record !~# '^.\?\t'
     return {}
   endif
   let m = matchlist(record, printf(
-        \ '^\s\+\(%s\):\s\+\("[^"]\{-}"\|.\{-}\)\%( -> \("[^"]\{-}"\|[^ ]\+\)\)\?$',
+        \ '^.\?\s\+\(%s\):\s\+\("[^"]\{-}"\|.\{-}\)\%( -> \("[^"]\{-}"\|[^ ]\+\)\)\?$',
         \ join(keys(signs), '\|')
         \))
   if empty(m)


### PR DESCRIPTION
It seems the result of git status may includes leading #s in a long format.
https://github.com/lambdalisue/gina.vim/issues/159#issuecomment-374857984

So allow an any leading character when parse the line.

It fix #159