### PR TITLE
Add enable_message_history option

### DIFF
--- a/autoload/gina/core/console.vim
+++ b/autoload/gina/core/console.vim
@@ -79,7 +79,7 @@ endfunction
 
 function! s:message(msg) abort
   if g:gina#core#console#enable_message_history
-      return gina#core#console#echomsg(a:msg)
+    return gina#core#console#echomsg(a:msg)
   endif
   return gina#core#console#echo(a:msg)
 endfunction

--- a/autoload/gina/core/console.vim
+++ b/autoload/gina/core/console.vim
@@ -4,7 +4,7 @@ let s:Console.prefix = '[gina] '
 
 if has('nvim')
   function! gina#core#console#message(msg) abort
-    return gina#core#console#echo(a:msg)
+    return s:message(a:msg)
   endfunction
 else
   " NOTE:
@@ -25,7 +25,7 @@ else
   function! s:message_callback() abort
     while !empty(s:message_queue)
       let msg = remove(s:message_queue, 0)
-      call gina#core#console#echo(msg)
+      call s:message(msg)
     endwhile
     augroup gina_core_console_message_internal
       autocmd! *
@@ -76,3 +76,14 @@ function! gina#core#console#ask_or_cancel(...) abort
   endif
   return result
 endfunction
+
+function! s:message(msg) abort
+  if g:gina#core#console#enable_message_history
+      return gina#core#console#echomsg(a:msg)
+  endif
+  return gina#core#console#echo(a:msg)
+endfunction
+
+call gina#config(expand('<sfile>'), {
+      \ 'enable_message_history': 0,
+      \})

--- a/doc/gina.txt
+++ b/doc/gina.txt
@@ -2203,6 +2203,11 @@ g:gina#core#askpass#force_internal
 	See |gina-misc-askpass| for detail about "askpass".
 	Default: 0
 
+		*g:gina#core#console#enable_message_history*
+g:gina#core#console#enable_message_history
+	Save command messages in |message-history|.
+	Default: 0
+
 		*g:gina#core#emitter#modified_delay*
 g:gina#core#emitter#modified_delay
 	A delay in millisecon until "modified" event is emitted by


### PR DESCRIPTION
## Reason
`git push` echos useful messages. eg. error messages, pull-request's url
I'd like to use them on vim.
I always use `:Gina! push` command.
But, git command messages are not remained in vim's message history.
Though `g<` shows the last message, it will removed soon.
This pull-request is enable to solve the problem.

## Example
```
let g:gina#core#console#enable_message_history = 1
```

## Problem
Vim.Console.echomsg only displays the last line message, but messages are saved in message history.  
I used this pull-request branch in this gif.
<img src="https://user-images.githubusercontent.com/18519692/46287972-4ad99900-c5bf-11e8-8785-d17fdac4f60f.gif" width="640">
Do you have any idea?

## TODO
- [x] doc ~(I'll begin if there is a prospect of acception)~
