### PR TITLE
Make statusline component async to fix numerous issue on Vim 8.1

### DIFF
--- a/autoload/gina/core/emitter.vim
+++ b/autoload/gina/core/emitter.vim
@@ -43,34 +43,20 @@ function! s:on_modified(...) abort
   call win_gotoid(winid_saved)
 endfunction
 
-if has('nvim')
-  function! s:on_modified_delay() abort
-    if s:modified_timer isnot# v:null
-      " Do not emit 'modified' for previous 'modified:delay'
-      silent! call timer_stop(s:modified_timer)
-    endif
-    let s:modified_timer = timer_start(
-          \ g:gina#core#emitter#modified_delay,
-          \ function('s:emit_modified')
-          \)
-  endfunction
+function! s:on_modified_delay() abort
+  if s:modified_timer isnot# v:null
+    " Do not emit 'modified' for previous 'modified:delay'
+    silent! call timer_stop(s:modified_timer)
+  endif
+  let s:modified_timer = timer_start(
+        \ g:gina#core#emitter#modified_delay,
+        \ function('s:emit_modified')
+        \)
+endfunction
 
-  function! s:emit_modified(...) abort
-    call gina#core#emitter#emit('modified')
-  endfunction
-else
-  " NOTE:
-  " 'exit_cb' would delayed up to 'updatetime' when a job has called from
-  " a timer callback.
-  " while 'modified:delay' is used to update contents of 'gina-status'
-  " window, this delay is quite annoying (user have to type or wait after
-  " executing 'stage' action or whatever).
-  " so do NOT use timer even with 'modified:delay' event.
-  " Ref: https://github.com/vim-jp/issues/issues/1164
-  function! s:on_modified_delay() abort
-    call gina#core#emitter#emit('modified')
-  endfunction
-endif
+function! s:emit_modified(...) abort
+  call gina#core#emitter#emit('modified')
+endfunction
 
 if !exists('s:subscribed')
   let s:subscribed = 1

--- a/test/gina/core/emitter.vimspec
+++ b/test/gina/core/emitter.vimspec
@@ -44,45 +44,43 @@ Describe gina#core#emitter
           \)
   End
 
-  if has('nvim')
-    It emits 'modified' event a bit later by 'modified:delay' event
-      Assert Equals(tracker.modified_called_count, 0)
-      Assert Equals(tracker.modified_delay_called_count, 0)
-      call gina#core#emitter#emit('modified:delay')
-      Assert Equals(tracker.modified_called_count, 0)
-      Assert Equals(tracker.modified_delay_called_count, 1)
-      execute 'sleep' (g:gina#core#emitter#modified_delay * 4) . 'm'
-      Assert Equals(tracker.modified_called_count, 1)
-      Assert Equals(tracker.modified_delay_called_count, 1)
-    End
+  It emits 'modified' event a bit later by 'modified:delay' event
+    Assert Equals(tracker.modified_called_count, 0)
+    Assert Equals(tracker.modified_delay_called_count, 0)
+    call gina#core#emitter#emit('modified:delay')
+    Assert Equals(tracker.modified_called_count, 0)
+    Assert Equals(tracker.modified_delay_called_count, 1)
+    execute 'sleep' (g:gina#core#emitter#modified_delay * 4) . 'm'
+    Assert Equals(tracker.modified_called_count, 1)
+    Assert Equals(tracker.modified_delay_called_count, 1)
+  End
 
-    It squashes 'modified:delay' events emitted within 'modified_delay' milliseconds
-      Assert Equals(tracker.modified_called_count, 0)
-      Assert Equals(tracker.modified_delay_called_count, 0)
-      call gina#core#emitter#emit('modified:delay')
-      call gina#core#emitter#emit('modified:delay')
-      call gina#core#emitter#emit('modified:delay')
-      call gina#core#emitter#emit('modified:delay')
-      call gina#core#emitter#emit('modified:delay')
-      Assert Equals(tracker.modified_called_count, 0)
-      Assert Equals(tracker.modified_delay_called_count, 5)
-      execute 'sleep' (g:gina#core#emitter#modified_delay * 4) . 'm'
-      Assert Equals(tracker.modified_called_count, 1)
-      Assert Equals(tracker.modified_delay_called_count, 5)
-    End
+  It squashes 'modified:delay' events emitted within 'modified_delay' milliseconds
+    Assert Equals(tracker.modified_called_count, 0)
+    Assert Equals(tracker.modified_delay_called_count, 0)
+    call gina#core#emitter#emit('modified:delay')
+    call gina#core#emitter#emit('modified:delay')
+    call gina#core#emitter#emit('modified:delay')
+    call gina#core#emitter#emit('modified:delay')
+    call gina#core#emitter#emit('modified:delay')
+    Assert Equals(tracker.modified_called_count, 0)
+    Assert Equals(tracker.modified_delay_called_count, 5)
+    execute 'sleep' (g:gina#core#emitter#modified_delay * 4) . 'm'
+    Assert Equals(tracker.modified_called_count, 1)
+    Assert Equals(tracker.modified_delay_called_count, 5)
+  End
 
-    It emits 'modified:delay' event by modifing a buffer in a git repository
-      execute 'edit' fnameescape(Path.join(slit1.worktree, 'foo.txt'))
-      Assert Equals(tracker.modified_called_count, 0)
-      Assert Equals(tracker.modified_delay_called_count, 0)
-      execute "normal! ifoobar\<Esc>:w\<CR>"
-      Assert Equals(tracker.modified_called_count, 0)
-      Assert Equals(tracker.modified_delay_called_count, 1)
-      execute 'sleep' (g:gina#core#emitter#modified_delay * 4) . 'm'
-      Assert Equals(tracker.modified_called_count, 1)
-      Assert Equals(tracker.modified_delay_called_count, 1)
-    End
-  endif
+  It emits 'modified:delay' event by modifing a buffer in a git repository
+    execute 'edit' fnameescape(Path.join(slit1.worktree, 'foo.txt'))
+    Assert Equals(tracker.modified_called_count, 0)
+    Assert Equals(tracker.modified_delay_called_count, 0)
+    execute "normal! ifoobar\<Esc>:w\<CR>"
+    Assert Equals(tracker.modified_called_count, 0)
+    Assert Equals(tracker.modified_delay_called_count, 1)
+    execute 'sleep' (g:gina#core#emitter#modified_delay * 4) . 'm'
+    Assert Equals(tracker.modified_called_count, 1)
+    Assert Equals(tracker.modified_delay_called_count, 1)
+  End
 
   It DOES NOT emits 'modified:delay' event by modifing a buffer NOT in a git repository
     execute 'edit' fnameescape(Path.join(slit3.worktree, 'foo.txt'))


### PR DESCRIPTION
Executing 'sleep' would invokes asynchronous code execution and some features is not
allowed to be called from statusline from Vim 8.1.0342.

Using System.Job#wait() to make process call synchronous in statusline component
would cause numerous unwilling issues like #170, #182, or "Not allowed here" message.

So this commit made statusline components make fully asynchronous to prevent calling
System.Job#wait() from statusline.

Ref:
vim-jp/issues#1185