### PR TITLE
Expose `commit:checkout:track`

### DIFF
--- a/autoload/gina/action/commit.vim
+++ b/autoload/gina/action/commit.vim
@@ -7,7 +7,6 @@ function! gina#action#commit#define(binder) abort
         \ 'options': {},
         \})
   call a:binder.define('commit:checkout:track', function('s:on_checkout_track'), {
-        \ 'hidden': 1,
         \ 'description': 'Checkout a commit with a tracking branch',
         \ 'mapping_mode': 'nv',
         \ 'requirements': ['rev'],


### PR DESCRIPTION
I believe it's pretty common to `git checkout -b A origin/A` as well as `git checkout A`. It can be more helpful to show it at the `<tab>` list from gina-branch/gina-commit buffer.