### PR TITLE
Remove behavior patch of diffthis

### DIFF
--- a/autoload/gina/util.vim
+++ b/autoload/gina/util.vim
@@ -164,25 +164,13 @@ endfunction
 
 function! gina#util#diffthis() abort
   diffthis
-  augroup gina_internal_util_diffthis
-    autocmd! *
-    autocmd BufWinEnter *
-          \ if &diff && s:diffcount() == 1 |
-          \   call s:diffoff(0) |
-          \ endif
-  augroup END
   augroup gina_internal_util_diffthis_local
     autocmd! * <buffer>
-    autocmd BufWinLeave <buffer>
-          \ if &diff && s:diffcount() == 2 |
-          \   call s:diffoff_all() |
-          \ elseif &diff |
-          \   call s:diffoff(1) |
+    autocmd BufReadPost <buffer>
+          \ if &diff && &foldmethod !=# 'diff' |
+          \   setlocal foldmethod=diff |
           \ endif
-    autocmd BufWinEnter  <buffer> call gina#util#diffthis()
-    autocmd BufWritePost <buffer> call s:diffupdate(bufnr('%'))
   augroup END
-  call gina#util#diffupdate()
 endfunction
 
 function! gina#util#diffupdate() abort

--- a/test/gina/util.vimspec
+++ b/test/gina/util.vimspec
@@ -255,17 +255,4 @@ Describe gina#util
       " NO TEST
     End
   End
-
-  Describe #diffthis()
-    It adds autocmd to call "diffoff" when a buffer is closed
-      call gina#util#diffthis()
-      Assert True(exists('#gina_internal_util_diffthis'))
-    End
-  End
-
-  Describe #diffupdate()
-    It calls a "diffupdate" command a bit later
-      " NO TEST
-    End
-  End
 End


### PR DESCRIPTION
The behavior patch of diffthis is no longer required while Vim and
Neovim already implement 'hiddenoff' diffopt.

This commit should fix issue #191