### PR TITLE
Upgrade vital modules

### DIFF
--- a/autoload/vital/_gina/Data/List.vim
+++ b/autoload/vital/_gina/Data/List.vim
@@ -4,13 +4,17 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_gina#Data#List#import() abort', printf("return map({'combinations': '', 'and': '', 'sort_by': '', 'foldr1': '', 'sort': '', 'flatten': '', 'has_index': '', 'filter': '', 'find_indices': '', 'any': '', 'map': '', 'unshift': '', 'span': '', 'pop': '', 'binary_search': '', 'uniq_by': '', 'or': '', 'all': '', 'zip': '', 'find_last_index': '', 'find': '', 'partition': '', 'map_accum': '', 'permutations': '', 'break': '', 'max_by': '', 'foldl': '', 'foldr': '', 'find_index': '', 'drop_while': '', 'group_by': '', 'take_while': '', 'conj': '', 'push': '', 'char_range': '', 'cons': '', 'foldl1': '', 'intersect': '', 'concat': '', 'shift': '', 'clear': '', 'has_common_items': '', 'product': '', 'uncons': '', 'zip_fill': '', 'uniq': '', 'has': '', 'min_by': '', 'with_index': ''}, \"vital#_gina#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_gina#Data#List#import() abort', printf("return map({'combinations': '', 'and': '', 'sort_by': '', 'foldr1': '', 'sort': '', 'flatten': '', 'has_index': '', 'filter': '', 'find_indices': '', 'any': '', 'map': '', 'unshift': '', 'span': '', 'pop': '', 'binary_search': '', 'uniq_by': '', 'or': '', 'all': '', 'zip': '', 'find_last_index': '', 'find': '', 'partition': '', 'shift': '', 'permutations': '', 'break': '', 'max_by': '', 'foldl': '', 'foldr': '', 'new': '', 'find_index': '', 'drop_while': '', 'group_by': '', 'take_while': '', 'conj': '', 'push': '', 'char_range': '', 'cons': '', 'foldl1': '', 'intersect': '', 'concat': '', 'map_accum': '', 'clear': '', 'has_common_items': '', 'product': '', 'uncons': '', 'zip_fill': '', 'uniq': '', 'has': '', 'min_by': '', 'with_index': ''}, \"vital#_gina#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 " Utilities for list.
 
 let s:save_cpo = &cpo
 set cpo&vim
+
+function! s:new(size, f) abort
+  return map(range(a:size), a:f)
+endfunction
 
 function! s:pop(list) abort
   return remove(a:list, -1)

--- a/autoload/vital/_gina/Data/String.vim
+++ b/autoload/vital/_gina/Data/String.vim
@@ -498,50 +498,7 @@ function! s:strwidthpart_reverse(str, width) abort
   return matchstr(str, '\%>' . (vcol < 0 ? 0 : vcol) . 'v.*')
 endfunction
 
-if v:version >= 703
-  " Use builtin function.
-  let s:wcswidth = function('strwidth')
-else
-  function! s:wcswidth(str) abort
-    if a:str =~# '^[\x00-\x7f]*$'
-      return strlen(a:str)
-    endif
-    let mx_first = '^\(.\)'
-    let str = a:str
-    let width = 0
-    while 1
-      let ucs = char2nr(substitute(str, mx_first, '\1', ''))
-      if ucs == 0
-        break
-      endif
-      let width += s:_wcwidth(ucs)
-      let str = substitute(str, mx_first, '', '')
-    endwhile
-    return width
-  endfunction
-
-  " UTF-8 only.
-  function! s:_wcwidth(ucs) abort
-    let ucs = a:ucs
-    if (ucs >= 0x1100
-          \  && (ucs <= 0x115f
-          \  || ucs == 0x2329
-          \  || ucs == 0x232a
-          \  || (ucs >= 0x2e80 && ucs <= 0xa4cf
-          \      && ucs != 0x303f)
-          \  || (ucs >= 0xac00 && ucs <= 0xd7a3)
-          \  || (ucs >= 0xf900 && ucs <= 0xfaff)
-          \  || (ucs >= 0xfe30 && ucs <= 0xfe6f)
-          \  || (ucs >= 0xff00 && ucs <= 0xff60)
-          \  || (ucs >= 0xffe0 && ucs <= 0xffe6)
-          \  || (ucs >= 0x20000 && ucs <= 0x2fffd)
-          \  || (ucs >= 0x30000 && ucs <= 0x3fffd)
-          \  ))
-      return 2
-    endif
-    return 1
-  endfunction
-endif
+let s:wcswidth = function('strwidth')
 
 function! s:remove_ansi_sequences(text) abort
   return substitute(a:text, '\e\[\%(\%(\d\+;\)*\d\+\)\?[mK]', '', 'g')

--- a/autoload/vital/_gina/Prelude.vim
+++ b/autoload/vital/_gina/Prelude.vim
@@ -10,60 +10,28 @@ delfunction s:_SID
 let s:save_cpo = &cpo
 set cpo&vim
 
-if v:version > 703 ||
-\  (v:version == 703 && has('patch465'))
-  function! s:glob(expr) abort
-    return glob(a:expr, 1, 1)
-  endfunction
-else
-  function! s:glob(expr) abort
-    return split(glob(a:expr, 1), '\n')
-  endfunction
-endif
+function! s:glob(expr) abort
+  return glob(a:expr, 1, 1)
+endfunction
 
-if v:version > 704 ||
-\  (v:version == 704 && has('patch279'))
-  function! s:globpath(path, expr) abort
-    return globpath(a:path, a:expr, 1, 1)
-  endfunction
-else
-  function! s:globpath(path, expr) abort
-    return split(globpath(a:path, a:expr, 1), '\n')
-  endfunction
-endif
+function! s:globpath(path, expr) abort
+  return globpath(a:path, a:expr, 1, 1)
+endfunction
 
 " Wrapper functions for type().
-" NOTE: __TYPE_FLOAT = -1 when -float.
-" this doesn't match to anything.
-if has('patch-7.4.2071')
-  let [
-  \   s:__TYPE_NUMBER,
-  \   s:__TYPE_STRING,
-  \   s:__TYPE_FUNCREF,
-  \   s:__TYPE_LIST,
-  \   s:__TYPE_DICT,
-  \   s:__TYPE_FLOAT] = [
-        \   v:t_number,
-        \   v:t_string,
-        \   v:t_func,
-        \   v:t_list,
-        \   v:t_dict,
-        \   v:t_float]
-else
-  let [
-  \   s:__TYPE_NUMBER,
-  \   s:__TYPE_STRING,
-  \   s:__TYPE_FUNCREF,
-  \   s:__TYPE_LIST,
-  \   s:__TYPE_DICT,
-  \   s:__TYPE_FLOAT] = [
-        \   type(3),
-        \   type(''),
-        \   type(function('tr')),
-        \   type([]),
-        \   type({}),
-        \   has('float') ? type(str2float('0')) : -1]
-endif
+let [
+\   s:__TYPE_NUMBER,
+\   s:__TYPE_STRING,
+\   s:__TYPE_FUNCREF,
+\   s:__TYPE_LIST,
+\   s:__TYPE_DICT,
+\   s:__TYPE_FLOAT] = [
+      \   v:t_number,
+      \   v:t_string,
+      \   v:t_func,
+      \   v:t_list,
+      \   v:t_dict,
+      \   v:t_float]
 
 " Number or Float
 function! s:is_numeric(Value) abort
@@ -176,56 +144,10 @@ function! s:strwidthpart_reverse(str, width) abort
   return ret
 endfunction
 
-if v:version >= 703
-  " Use builtin function.
-  function! s:wcswidth(str) abort
-    call s:_warn_deprecated('wcswidth', 'Data.String.wcswidth')
-    return strwidth(a:str)
-  endfunction
-else
-  function! s:wcswidth(str) abort
-    call s:_warn_deprecated('wcswidth', 'Data.String.wcswidth')
-
-    if a:str =~# '^[\x00-\x7f]*$'
-      return strlen(a:str)
-    end
-
-    let mx_first = '^\(.\)'
-    let str = a:str
-    let width = 0
-    while 1
-      let ucs = char2nr(substitute(str, mx_first, '\1', ''))
-      if ucs == 0
-        break
-      endif
-      let width += s:_wcwidth(ucs)
-      let str = substitute(str, mx_first, '', '')
-    endwhile
-    return width
-  endfunction
-
-  " UTF-8 only.
-  function! s:_wcwidth(ucs) abort
-    let ucs = a:ucs
-    if (ucs >= 0x1100
-          \  && (ucs <= 0x115f
-          \  || ucs == 0x2329
-          \  || ucs == 0x232a
-          \  || (ucs >= 0x2e80 && ucs <= 0xa4cf
-          \      && ucs != 0x303f)
-          \  || (ucs >= 0xac00 && ucs <= 0xd7a3)
-          \  || (ucs >= 0xf900 && ucs <= 0xfaff)
-          \  || (ucs >= 0xfe30 && ucs <= 0xfe6f)
-          \  || (ucs >= 0xff00 && ucs <= 0xff60)
-          \  || (ucs >= 0xffe0 && ucs <= 0xffe6)
-          \  || (ucs >= 0x20000 && ucs <= 0x2fffd)
-          \  || (ucs >= 0x30000 && ucs <= 0x3fffd)
-          \  ))
-      return 2
-    endif
-    return 1
-  endfunction
-endif
+function! s:wcswidth(str) abort
+  call s:_warn_deprecated('wcswidth', 'Data.String.wcswidth')
+  return strwidth(a:str)
+endfunction
 
 let s:is_windows = has('win32') " This means any versions of windows https://github.com/vim-jp/vital.vim/wiki/Coding-Rule#how-to-check-if-the-runtime-os-is-windows
 let s:is_cygwin = has('win32unix')

--- a/autoload/vital/_gina/Process.vim
+++ b/autoload/vital/_gina/Process.vim
@@ -21,10 +21,6 @@ set cpo&vim
 " Because these variables are used when this script file is loaded.
 let s:is_windows = has('win32') " This means any versions of windows https://github.com/vim-jp/vital.vim/wiki/Coding-Rule#how-to-check-if-the-runtime-os-is-windows
 let s:is_unix = has('unix')
-" As of 7.4.122, the system()'s 1st argument is converted internally by Vim.
-" Note that Patch 7.4.122 does not convert system()'s 2nd argument and
-" return-value. We must convert them manually.
-let s:need_trans = v:version < 704 || (v:version == 704 && !has('patch122'))
 
 let s:TYPE_DICT = type({})
 let s:TYPE_LIST = type([])
@@ -127,9 +123,6 @@ function! s:system(str, ...) abort
     let command = a:str
   else
     throw 'vital: Process: invalid argument (value type:' . type(a:str) . ')'
-  endif
-  if s:need_trans
-    let command = s:iconv(command, &encoding, 'char')
   endif
   let args = [command] + args
   if background && (use_vimproc || !s:is_windows)

--- a/autoload/vital/_gina/System/File.vim
+++ b/autoload/vital/_gina/System/File.vim
@@ -26,10 +26,6 @@ let s:is_cygwin = has('win32unix')
 let s:is_mac = !s:is_windows && !s:is_cygwin
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
-" As of 7.4.122, the system()'s 1st argument is converted internally by Vim.
-" Note that Patch 7.4.122 does not convert system()'s 2nd argument and
-" return-value. We must convert them manually.
-let s:need_trans = v:version < 704 || (v:version == 704 && !has('patch122'))
 
 " Open a file.
 function! s:open(filename) abort
@@ -38,9 +34,6 @@ function! s:open(filename) abort
   " Detect desktop environment.
   if s:is_windows
     " For URI only.
-    if s:need_trans
-      let filename = iconv(filename, &encoding, 'char')
-    endif
     " Note:
     "   # and % required to be escaped (:help cmdline-special)
     silent execute printf(
@@ -126,13 +119,8 @@ elseif s:is_windows
     let dest = substitute(dest, '[/\\]\+', '\', 'g')
     " src must not have trailing '\'.
     let src  = substitute(src, '\\$', '', 'g')
-    " All characters must be encoded to system encoding.
-    if s:need_trans
-      let src  = iconv(src, &encoding, 'char')
-      let dest = iconv(dest, &encoding, 'char')
-    endif
     let cmd_exe = (&shell =~? 'cmd\.exe$' ? '' : 'cmd /c ')
-    call system(cmd_exe . 'move /y ' . src  . ' ' . dest)
+    call system(cmd_exe . 'move /y "' . src  . '" "' . dest . '"')
     return !v:shell_error
   endfunction
 else
@@ -173,7 +161,7 @@ elseif s:is_windows
     endif
     let src  = s:_shellescape_robocopy(a:src)
     let dest = s:_shellescape_robocopy(a:dest)
-    call system('robocopy /e ' . src . ' ' . dest)
+    call system('robocopy /e "' . src . '" "' . dest . '"')
     return v:shell_error <# 8
   endfunction
   function! s:_shellescape_robocopy(path) abort
@@ -266,7 +254,7 @@ elseif s:is_windows
     let src  = substitute(src, '/', '\', 'g')
     let dest = substitute(dest, '/', '\', 'g')
     let cmd_exe = (&shell =~? 'cmd\.exe$' ? '' : 'cmd /c ')
-    call system(cmd_exe . 'copy /y ' . src . ' ' . dest)
+    call system(cmd_exe . 'copy /y "' . src . '" "' . dest . '"')
     return !v:shell_error
   endfunction
 else
@@ -298,50 +286,14 @@ endfunction
 
 
 " Delete a file/directory.
-if has('patch-7.4.1128')
-  function! s:rmdir(path, ...) abort
-    let flags = a:0 ? a:1 : ''
-    let delete_flags = flags =~# 'r' ? 'rf' : 'd'
-    let result = delete(a:path, delete_flags)
-    if result == -1
-      throw 'vital: System.File: rmdir(): cannot delete "' . a:path . '"'
-    endif
-  endfunction
-
-elseif s:is_unix
-  function! s:rmdir(path, ...) abort
-    let flags = a:0 ? a:1 : ''
-    let cmd = flags =~# 'r' ? 'rm -rf' : 'rmdir'
-    let ret = system(cmd . ' ' . shellescape(a:path))
-    if v:shell_error
-      let ret = iconv(ret, 'char', &encoding)
-      throw 'vital: System.File: rmdir(): ' . substitute(ret, '\n', '', 'g')
-    endif
-  endfunction
-
-elseif s:is_windows
-  function! s:rmdir(path, ...) abort
-    let flags = a:0 ? a:1 : ''
-    if &shell =~? 'sh$'
-      let cmd = flags =~# 'r' ? 'rm -rf' : 'rmdir'
-      let ret = system(cmd . ' ' . shellescape(a:path))
-    else
-      " 'f' flag does not make sense.
-      let cmd = 'rmdir /Q'
-      let cmd .= flags =~# 'r' ? ' /S' : ''
-      let ret = system(cmd . ' "' . a:path . '"')
-    endif
-    if v:shell_error
-      let ret = iconv(ret, 'char', &encoding)
-      throw 'vital: System.File: rmdir(): ' . substitute(ret, '\n', '', 'g')
-    endif
-  endfunction
-
-else
-  function! s:rmdir(...) abort
-    throw 'vital: System.File: rmdir(): your platform is not supported'
-  endfunction
-endif
+function! s:rmdir(path, ...) abort
+  let flags = a:0 ? a:1 : ''
+  let delete_flags = flags =~# 'r' ? 'rf' : 'd'
+  let result = delete(a:path, delete_flags)
+  if result == -1
+    throw 'vital: System.File: rmdir(): cannot delete "' . a:path . '"'
+  endif
+endfunction
 
 
 let &cpo = s:save_cpo

--- a/autoload/vital/_gina/System/Job/Vim.vim
+++ b/autoload/vital/_gina/System/Job/Vim.vim
@@ -20,6 +20,9 @@ function! s:start(args, options) abort
         \ 'mode': 'raw',
         \ 'timeout': 0,
         \}
+  if has('patch-8.1.889')
+    let job_options['noblock'] = 1
+  endif
   if has_key(job, 'on_stdout')
     let job_options.out_cb = funcref('s:_out_cb', [job])
   else

--- a/autoload/vital/_gina/Vim/Buffer/Writer.vim
+++ b/autoload/vital/_gina/Vim/Buffer/Writer.vim
@@ -134,11 +134,16 @@ function! s:replace(expr, start, end, replacement) abort
   endif
   let data = s:_iconv(bufnr, a:replacement)
   let modifiable = getbufvar(bufnr, '&modifiable')
+  let buflisted = getbufvar(bufnr, '&buflisted')
+  let readonly = getbufvar(bufnr, '&readonly')
   try
     call setbufvar(bufnr, '&modifiable', 1)
+    call setbufvar(bufnr, '&readonly', 0)
     return s:_replace(bufnr, a:start, a:end, data)
   finally
     call setbufvar(bufnr, '&modifiable', modifiable)
+    call setbufvar(bufnr, '&buflisted', buflisted)
+    call setbufvar(bufnr, '&readonly', readonly)
   endtry
 endfunction
 

--- a/autoload/vital/_gina/Vim/Guard.vim
+++ b/autoload/vital/_gina/Vim/Guard.vim
@@ -29,12 +29,10 @@ function! s:_vital_created(module) abort
   " define constant variables
   if !exists('s:const')
     let s:const = {}
-    let s:const.is_local_variable_supported =
-        \ v:version > 703 || (v:version == 703 && has('patch560'))
-    " NOTE:
-    " The third argument is available from 7.4.242 but it had bug and that
-    " bug was fixed from 7.4.513
-    let s:const.is_third_argument_of_getreg_supported = has('patch-7.4.513')
+    " These variables are provided for 7.4 or earlier.
+    " But we leave this code to keep API.
+    let s:const.is_local_variable_supported = 1
+    let s:const.is_third_argument_of_getreg_supported = 1
     lockvar s:const
   endif
   call extend(a:module, s:const)
@@ -85,11 +83,7 @@ function! s:_new_register(name) abort
   let name = a:name ==# '@@' ? '' : a:name[1]
   let register = copy(s:register)
   let register.name = name
-  if s:const.is_third_argument_of_getreg_supported
-    let register.value = getreg(name, 1, 1)
-  else
-    let register.value = getreg(name, 1)
-  endif
+  let register.value = getreg(name, 1, 1)
   let register.type = getregtype(name)
   return register
 endfunction

--- a/autoload/vital/gina.vim
+++ b/autoload/vital/gina.vim
@@ -6,21 +6,6 @@ let s:is_vital_vim = s:plugin_name is# 'vital'
 let s:loaded = {}
 let s:cache_sid = {}
 
-" function() wrapper
-if v:version > 703 || v:version == 703 && has('patch1170')
-  function! s:_function(fstr) abort
-    return function(a:fstr)
-  endfunction
-else
-  function! s:_SID() abort
-    return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
-  endfunction
-  let s:_s = '<SNR>' . s:_SID() . '_'
-  function! s:_function(fstr) abort
-    return function(substitute(a:fstr, 's:', s:_s, 'g'))
-  endfunction
-endif
-
 function! vital#{s:plugin_name}#new() abort
   return s:new(s:plugin_name)
 endfunction
@@ -48,7 +33,7 @@ function! s:vital_files() abort
   endif
   return copy(s:vital_files)
 endfunction
-let s:Vital.vital_files = s:_function('s:vital_files')
+let s:Vital.vital_files = function('s:vital_files')
 
 function! s:import(name, ...) abort dict
   let target = {}
@@ -73,7 +58,7 @@ function! s:import(name, ...) abort dict
   endif
   return target
 endfunction
-let s:Vital.import = s:_function('s:import')
+let s:Vital.import = function('s:import')
 
 function! s:load(...) abort dict
   for arg in a:000
@@ -100,14 +85,14 @@ function! s:load(...) abort dict
   endfor
   return self
 endfunction
-let s:Vital.load = s:_function('s:load')
+let s:Vital.load = function('s:load')
 
 function! s:unload() abort dict
   let s:loaded = {}
   let s:cache_sid = {}
   unlet! s:vital_files
 endfunction
-let s:Vital.unload = s:_function('s:unload')
+let s:Vital.unload = function('s:unload')
 
 function! s:exists(name) abort dict
   if a:name !~# '\v^\u\w*%(\.\u\w*)*$'
@@ -115,19 +100,19 @@ function! s:exists(name) abort dict
   endif
   return s:_module_path(a:name) isnot# ''
 endfunction
-let s:Vital.exists = s:_function('s:exists')
+let s:Vital.exists = function('s:exists')
 
 function! s:search(pattern) abort dict
   let paths = s:_extract_files(a:pattern, self.vital_files())
   let modules = sort(map(paths, 's:_file2module(v:val)'))
   return s:_uniq(modules)
 endfunction
-let s:Vital.search = s:_function('s:search')
+let s:Vital.search = function('s:search')
 
 function! s:plugin_name() abort dict
   return self._plugin_name
 endfunction
-let s:Vital.plugin_name = s:_function('s:plugin_name')
+let s:Vital.plugin_name = function('s:plugin_name')
 
 function! s:_self_vital_files() abort
   let builtin = printf('%s/__%s__/', s:vital_base_dir, s:plugin_name)
@@ -178,7 +163,7 @@ function! s:_import(name) abort dict
   endif
   return copy(s:loaded[a:name])
 endfunction
-let s:Vital._import = s:_function('s:_import')
+let s:Vital._import = function('s:_import')
 
 " s:_get_module() returns module object wihch has all script local functions.
 function! s:_get_module(name) abort dict
@@ -196,9 +181,9 @@ endfunction
 
 if s:is_vital_vim
   " For vital.vim, we can use s:_get_builtin_module directly
-  let s:Vital._get_module = s:_function('s:_get_builtin_module')
+  let s:Vital._get_module = function('s:_get_builtin_module')
 else
-  let s:Vital._get_module = s:_function('s:_get_module')
+  let s:Vital._get_module = function('s:_get_module')
 endif
 
 function! s:_import_func_name(plugin_name, module_name) abort

--- a/autoload/vital/gina.vital
+++ b/autoload/vital/gina.vital
@@ -1,5 +1,5 @@
 gina
-9b584074f2d64bc538d635e21fb67f71a00b2b2a
+d2119cf55230863a1950e491388c2f62fbcaf3c2
 
 System.File
 Data.List


### PR DESCRIPTION
Vim 8.1.889 is the version which `noblock` option becomes stable in Windows. [ref](https://vim-jp.slack.com/archives/C03C4RC9F/p1550110161242800)
The `noblock` option itself is supported from Vim 8.1.0350.

I'm not sure if I should make it available from Vim 8.1.0350 when the OS is not Windows.