### PR TITLE
bug fix: `split #` fails if the filename of `#` is empty

### DIFF
--- a/autoload/gina/command/commit.vim
+++ b/autoload/gina/command/commit.vim
@@ -302,10 +302,10 @@ function! s:QuitPre() abort
   let args = gina#core#meta#get('args', v:null)
   if args isnot# v:null && get(args.params, 'restore')
     let win_id = win_getid()
-    if bufnr('#') == -1
-      silent keepalt keepjumps 1new
-    else
+    if len(bufname('#')) && bufnr('#') != -1
       silent keepalt keepjumps 1split #
+    else
+      silent keepalt keepjumps 1new
     endif
     call win_gotoid(win_id)
   endif

--- a/autoload/gina/command/commit.vim
+++ b/autoload/gina/command/commit.vim
@@ -302,7 +302,7 @@ function! s:QuitPre() abort
   let args = gina#core#meta#get('args', v:null)
   if args isnot# v:null && get(args.params, 'restore')
     let win_id = win_getid()
-    if len(bufname('#')) && bufnr('#') != -1
+    if !empty(bufname('#')) && bufnr('#') isnot# -1
       silent keepalt keepjumps 1split #
     else
       silent keepalt keepjumps 1new


### PR DESCRIPTION
closes #211

When you try to `split #` and `bufname('#')` is empty, Neovim will throw this exception:

```
E499: Empty file name for '%' or '#', only works with "p:h"
```

This PR adds and extra check for empty filenames before trying to `split #`.