### PR TITLE
add check v:version

### DIFF
--- a/plugin/gina.vim
+++ b/plugin/gina.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_gina')
+if exists('g:loaded_gina') && v:version < 800
   finish
 endif
 let g:loaded_gina = 1


### PR DESCRIPTION
Hi!

In this document, gina support `Vim 8.0.0107 or above or Neovim 0.2.0`

Therefore, I added checking about v:version < 800 in plugin dir.

Please check this Pull Request!