### PR TITLE
Remove diffoff and group from blame/chaperon/patch/compare

### DIFF
--- a/autoload/gina/command/blame.vim
+++ b/autoload/gina/command/blame.vim
@@ -104,8 +104,8 @@ endfunction
 function! s:build_args(git, args, range) abort
   let args = a:args.clone()
   let args.params.groups = [
-        \ args.pop('--group1', 'blame-body'),
-        \ args.pop('--group2', 'blame-navi'),
+        \ args.pop('--group1', ''),
+        \ args.pop('--group2', ''),
         \]
   let args.params.opener = args.pop('--opener', 'tabnew')
   let args.params.width = args.pop('--width', v:null)

--- a/autoload/gina/command/chaperon.vim
+++ b/autoload/gina/command/chaperon.vim
@@ -70,9 +70,9 @@ endfunction
 function! s:build_args(git, args) abort
   let args = a:args.clone()
   let args.params.groups = [
-        \ args.pop('--group1', 'chaperon-l'),
-        \ args.pop('--group2', 'chaperon-c'),
-        \ args.pop('--group3', 'chaperon-r'),
+        \ args.pop('--group1', ''),
+        \ args.pop('--group2', ''),
+        \ args.pop('--group3', ''),
         \]
   let args.params.opener = args.pop('--opener', 'tabnew')
   let args.params.diffoff = args.pop('--diffoff')

--- a/autoload/gina/command/chaperon.vim
+++ b/autoload/gina/command/chaperon.vim
@@ -60,6 +60,10 @@ function! s:get_options() abort
         \ '--col=',
         \ 'An initial column number.',
         \)
+  call options.define(
+        \ '--diffoff',
+        \ 'Call diffoff! prior to open buffers.',
+        \)
   return options
 endfunction
 
@@ -71,6 +75,7 @@ function! s:build_args(git, args) abort
         \ args.pop('--group3', 'chaperon-r'),
         \]
   let args.params.opener = args.pop('--opener', 'tabnew')
+  let args.params.diffoff = args.pop('--diffoff')
   call gina#core#args#extend_path(a:git, args, args.pop(1))
   call gina#core#args#extend_line(a:git, args, args.pop('--line'))
   call gina#core#args#extend_col(a:git, args, args.pop('--col'))
@@ -88,7 +93,10 @@ function! s:call(range, args, mods) abort
         \ ? 'split'
         \ : 'vsplit'
 
-  diffoff!
+  if !empty(args.params.diffoff)
+    diffoff!
+  endif
+
   call s:open(0, mods, opener1, ':2', args.params)
   let bufnr1 = bufnr('%')
 

--- a/autoload/gina/command/compare.vim
+++ b/autoload/gina/command/compare.vim
@@ -59,6 +59,10 @@ function! s:get_options() abort
         \ '-R',
         \ 'Reverse the buffer order',
         \)
+  call options.define(
+        \ '--diffoff',
+        \ 'Call diffoff! prior to open buffers.',
+        \)
   return options
 endfunction
 
@@ -71,6 +75,7 @@ function! s:build_args(git, args) abort
   let args.params.opener = args.pop('--opener', 'tabnew')
   let args.params.cached = args.get('--cached')
   let args.params.R = args.get('-R')
+  let args.params.diffoff = args.pop('--diffoff')
 
   call gina#core#args#extend_treeish(a:git, args, args.pop(1, ':'))
   call gina#core#args#extend_diff(a:git, args, args.params.rev)
@@ -92,7 +97,10 @@ function! s:call(range, args, mods) abort
         \ ? 'keepalt ' . a:mods
         \ : join(['keepalt', 'rightbelow', a:mods])
 
-  diffoff!
+  if !empty(args.params.diffoff)
+    diffoff!
+  endif
+
   let opener1 = args.params.opener
   let opener2 = empty(matchstr(&diffopt, 'vertical'))
         \ ? 'split'

--- a/autoload/gina/command/compare.vim
+++ b/autoload/gina/command/compare.vim
@@ -69,8 +69,8 @@ endfunction
 function! s:build_args(git, args) abort
   let args = a:args.clone()
   let args.params.groups = [
-        \ args.pop('--group1', 'compare-l'),
-        \ args.pop('--group2', 'compare-r'),
+        \ args.pop('--group1', ''),
+        \ args.pop('--group2', ''),
         \]
   let args.params.opener = args.pop('--opener', 'tabnew')
   let args.params.cached = args.get('--cached')

--- a/autoload/gina/command/patch.vim
+++ b/autoload/gina/command/patch.vim
@@ -73,9 +73,9 @@ endfunction
 function! s:build_args(git, args) abort
   let args = a:args.clone()
   let args.params.groups = [
-        \ args.pop('--group1', 'patch-l'),
-        \ args.pop('--group2', 'patch-c'),
-        \ args.pop('--group3', 'patch-r'),
+        \ args.pop('--group1', ''),
+        \ args.pop('--group2', ''),
+        \ args.pop('--group3', ''),
         \]
   let args.params.no_group = args.pop('--no-group', 0)
   let args.params.opener = args.pop('--opener', 'tabnew')

--- a/autoload/gina/command/patch.vim
+++ b/autoload/gina/command/patch.vim
@@ -63,6 +63,10 @@ function! s:get_options() abort
         \ '--oneside',
         \ 'Use two buffers instead of three buffers.',
         \)
+  call options.define(
+        \ '--diffoff',
+        \ 'Call diffoff! prior to open buffers.',
+        \)
   return options
 endfunction
 
@@ -76,6 +80,7 @@ function! s:build_args(git, args) abort
   let args.params.no_group = args.pop('--no-group', 0)
   let args.params.opener = args.pop('--opener', 'tabnew')
   let args.params.oneside = args.pop('--oneside', 0)
+  let args.params.diffoff = args.pop('--diffoff')
   call gina#core#args#extend_path(a:git, args, args.pop(1))
   call gina#core#args#extend_line(a:git, args, args.pop('--line'))
   call gina#core#args#extend_col(a:git, args, args.pop('--col'))
@@ -116,7 +121,10 @@ function! s:call(range, args, mods) abort
         \ ? 'keepalt ' . a:mods
         \ : join(['keepalt', 'rightbelow', a:mods])
 
-  diffoff!
+  if !empty(args.params.diffoff)
+    diffoff!
+  endif
+
   let opener1 = args.params.opener
   let opener2 = empty(matchstr(&diffopt, 'vertical'))
         \ ? 'split'


### PR DESCRIPTION
1. Diffs are local to a tab page so `diffoff!` is not required for default opener `tabnew`
2. Group feature is useful for non file-like buffers and it's not required for blame/chaperon/patch/compare usually