### PR TITLE
Fix a problem with fixup commit failing

### DIFF
--- a/autoload/gina/command/commit.vim
+++ b/autoload/gina/command/commit.vim
@@ -221,6 +221,8 @@ function! s:is_raw_command(args) abort
     return 1
   elseif a:args.get('-t|--template')
     return 0
+  elseif !empty(a:args.get('--fixup', ''))
+    return 1
   endif
   return 0
 endfunction


### PR DESCRIPTION
### Environment

- macOS Catalina 10.15.5
- Neovim (NVIM v0.5.0-nightly-348-g1ca67a73c)
- git version 2.27.0

### Problem

`Gina commit --fixup {hash}` opens a buffer for the commit and fails to save it, resulting in an error.
Fixup commit doesn't need to open a buffer, so I think the behavior is incorrect.

Error: `[gina] fatal: Only one of -c/-C/-F/--fixup can be used.`

```
[gina] Fail: env GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/Users/user_name/dotfiles/.vim/bundle/.cache/init.vim/.dein/scripts/askpass.mac git --no-pager -c core.editor=false -c color.status=always
-C /Users/user_name/repos/github.com/yuki-ycino/fzf-preview.zsh commit --fixup 826e9482eeaa0a38f821fb4507721e87f7ae9960 --no-edit --cleanup=strip --file=/var/folders/9w/0mzs87p55y97ys6zlkcgk
ll40000gn/T/nvimviH7wC/1
```

Read the code and fix it to run as raw command if it has the --fixup option
It appears to be working in my environment.
Is there a problem with the changes?