### PR TITLE
Fix git instances for buffers are not cached

### DIFF
--- a/autoload/gina/core.vim
+++ b/autoload/gina/core.vim
@@ -100,7 +100,7 @@ function! s:get_cached_instance(expr) abort
 endfunction
 
 function! s:set_cached_instance(expr, git) abort
-  if bufexists(a:expr)
+  if bufexists(bufname(a:expr))
     call setbufvar(a:expr, 'gina', {
           \ 'refname': get(a:git, 'refname', ''),
           \ 'bufname': simplify(bufname(a:expr)),

--- a/autoload/gina/core.vim
+++ b/autoload/gina/core.vim
@@ -100,7 +100,7 @@ function! s:get_cached_instance(expr) abort
 endfunction
 
 function! s:set_cached_instance(expr, git) abort
-  if bufexists(bufname(a:expr))
+  if bufexists(bufnr(a:expr))
     call setbufvar(a:expr, 'gina', {
           \ 'refname': get(a:git, 'refname', ''),
           \ 'bufname': simplify(bufname(a:expr)),


### PR DESCRIPTION
When `gina#core#get()` is called, vital's git object is created but not cached, because `bufexists('%')` always returns 0.
This PR fixes this using `bufname()` for the expression.