### PR TITLE
Improve format of Gina-log buffer

### DIFF
--- a/autoload/gina/command/log.vim
+++ b/autoload/gina/command/log.vim
@@ -66,7 +66,8 @@ function! s:build_args(git, args) abort
   let args.params.partial = !empty(args.residual())
 
   call args.set('--color', 'always')
-  call args.set('--pretty', "format:\e[32m%h\e[m %s \e[33;1m%cr\e[m \e[35;1m<%an>\e[m\e[36;1m%d\e[m")
+  call args.set('--date', 'human')
+  call args.set('--pretty', "format:\e[32m%h\e[m %<(30,trunc)%s \e[33;1m%cd\e[m \e[35;1m%an\e[m\e[36;1m%d\e[m")
   call gina#core#args#extend_treeish(a:git, args, args.pop(1, v:null))
   if args.params.path isnot# v:null
     call args.residual([args.params.path] + args.residual())

--- a/test/gina/command/log.vimspec
+++ b/test/gina/command/log.vimspec
@@ -32,11 +32,11 @@ Describe gina#command#log
       Assert Equals(bufname('%'), printf('gina://%s:log', slit1.refname))
       Assert Match(
             \ getline(1),
-            \ '\* [32m\w\{7}[m Thrid [33;1m\d\+ seconds\? ago[m [35;1m<.*>[m[36;1m (.*)[m'
+            \ '\* [32m\w\{7}[m Thrid\s\{25} [33;1m\d\+ seconds\? ago[m [35;1m.*[m[36;1m (.*)[m'
             \)
       Assert Match(
             \ getline(2),
-            \ '\* [32m\w\{7}[m First [33;1m\d\+ seconds\? ago[m [35;1m<.*>[m[36;1m[m'
+            \ '\* [32m\w\{7}[m First\s\{25} [33;1m\d\+ seconds\? ago[m [35;1m.*[m[36;1m[m'
             \)
       Assert Equals(line('$'), 2)
     End
@@ -47,7 +47,7 @@ Describe gina#command#log
       Assert Equals(bufname('%'), printf('gina://%s:log:--', slit1.refname))
       Assert Match(
             \ getline(1),
-            \ '\* [32m\w\{7}[m First [33;1m\d\+ seconds\? ago[m [35;1m<.*>[m[36;1m[m'
+            \ '\* [32m\w\{7}[m First\s\{25} [33;1m\d\+ seconds\? ago[m [35;1m.*[m[36;1m[m'
             \)
       Assert Equals(line('$'), 1)
     End
@@ -58,11 +58,11 @@ Describe gina#command#log
       Assert Equals(bufname('%'), printf('gina://%s:log:--', slit1.refname))
       Assert Match(
             \ getline(1),
-            \ '\* [32m\w\{7}[m Thrid [33;1m\d\+ seconds\? ago[m [35;1m<.*>[m[36;1m (.*)[m'
+            \ '\* [32m\w\{7}[m Thrid\s\{25} [33;1m\d\+ seconds\? ago[m [35;1m.*[m[36;1m (.*)[m'
             \)
       Assert Match(
             \ getline(2),
-            \ '\* [32m\w\{7}[m First [33;1m\d\+ seconds\? ago[m [35;1m<.*>[m[36;1m[m'
+            \ '\* [32m\w\{7}[m First\s\{25} [33;1m\d\+ seconds\? ago[m [35;1m.*[m[36;1m[m'
             \)
       Assert Equals(line('$'), 2)
     End
@@ -75,7 +75,7 @@ Describe gina#command#log
       Assert Equals(bufname('%'), printf('gina://%s:log/:A/foo.txt:$', slit1.refname))
       Assert Match(
             \ getline(1),
-            \ '\* [32m\w\{7}[m First [33;1m\d\+ seconds\? ago[m [35;1m<.*>[m[36;1m[m'
+            \ '\* [32m\w\{7}[m First\s\{25} [33;1m\d\+ seconds\? ago[m [35;1m.*[m[36;1m[m'
             \)
       Assert Equals(line('$'), 1)
     End


### PR DESCRIPTION
I changed the format of Gina-log buffer. How about this?

## Changes

* Truncate commit summary (length: `30`).
    Using this placeholder:
    ```
    %<(<N>[,trunc|ltrunc|mtrunc])
    make the next placeholder take at least N columns, padding spaces on the right if necessary. Optionally truncate at the 
    beginning (ltrunc), the middle (mtrunc) or the end (trunc) if the output is longer than N columns. Note that truncating only 
    works correctly with N >= 2.
    ```
    [Git - git-log Documentation](https://git-scm.com/docs/git-log)
* Use the "human" date format.
    ```
    --date=human shows the timezone if the timezone does not match the current time-zone, and doesn’t print the whole date 
    if that matches (ie skip printing year for dates that are "this year", but also skip the whole date itself if it’s in the last few 
    days and we can just say what weekday it was). For older dates the hour and minute is also omitted.
    ```
    [Git - git-log Documentation](https://git-scm.com/docs/git-log) (same page)
* Remove brackets around author name.
    ```
    <author> -> author
    ```

If you don't like anything, please feel free to point out. (Especially the last one is just my preference...)

## Screen shots

### Before
<img width="960" alt="ss 2021-02-02 16 45 08" src="https://user-images.githubusercontent.com/64692680/106568101-279bcb80-6576-11eb-89a7-d26967e4e3fa.png">

### After
<img width="960" alt="ss 2021-02-02 16 45 37" src="https://user-images.githubusercontent.com/64692680/106568117-2ec2d980-6576-11eb-8fdc-9e22ab2cce95.png">

