### PR TITLE
Implement cmdline-completion for several git raw commands

### DIFF
--- a/autoload/gina/command.vim
+++ b/autoload/gina/command.vim
@@ -36,8 +36,6 @@ function! gina#command#complete(arglead, cmdline, cursorpos) abort
           \)
   elseif a:cmdline =~# printf('^.\{-}Gina\s\+%s$', a:arglead)
     return gina#complete#common#command(a:arglead, a:cmdline, a:cursorpos)
-  else
-    return []
   endif
   let cmdline = matchstr(a:cmdline, '^.\{-}Gina\s\+\zs.*')
   let scheme = matchstr(cmdline, '^\S\+')

--- a/autoload/gina/command/_raw.vim
+++ b/autoload/gina/command/_raw.vim
@@ -8,7 +8,14 @@ function! gina#command#_raw#call(range, args, mods) abort
 endfunction
 
 function! gina#command#_raw#complete(arglead, cmdline, cursorpos) abort
-  return gina#complete#filename#any(a:arglead, a:cmdline, a:cursorpos)
+  let args = gina#core#args#new(matchstr(a:cmdline, '^.*\ze .*'))
+  if empty(args.get(1))
+    return gina#complete#common#raw_command(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  if args.get(1) =~# '^\%(fetch\|pull\|push\|switch\)$'
+    return s:{args.get(1)}_complete(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  return []
 endfunction
 
 
@@ -20,6 +27,47 @@ function! s:build_args(git, args) abort
     call args.pop(0)
   endif
   return args.lock()
+endfunction
+
+function! s:fetch_complete(arglead, cmdline, cursorpos) abort
+  let args = gina#core#args#new(matchstr(a:cmdline, '^.*\ze .*'))
+  if empty(args.get(2))
+    return gina#complete#common#remote(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  if empty(args.get(3))
+    " TODO: Return refspecs in remote repository "args.get(2)".
+  endif
+  return []
+endfunction
+
+function! s:pull_complete(arglead, cmdline, cursorpos) abort
+  let args = gina#core#args#new(matchstr(a:cmdline, '^.*\ze .*'))
+  if empty(args.get(2))
+    return gina#complete#common#remote(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  if empty(args.get(3))
+    " TODO: Return refspecs in remote repository "args.get(2)".
+  endif
+  return []
+endfunction
+
+function! s:push_complete(arglead, cmdline, cursorpos) abort
+  let args = gina#core#args#new(matchstr(a:cmdline, '^.*\ze .*'))
+  if empty(args.get(2))
+    return gina#complete#common#remote(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  if empty(args.get(3))
+    return gina#complete#commit#local_branch(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  return []
+endfunction
+
+function! s:switch_complete(arglead, cmdline, cursorpos) abort
+  let args = gina#core#args#new(matchstr(a:cmdline, '^.*\ze .*'))
+  if empty(args.get(2))
+    return gina#complete#commit#local_branch(a:arglead, a:cmdline, a:cursorpos)
+  endif
+  return []
 endfunction
 
 

--- a/autoload/gina/complete/common.vim
+++ b/autoload/gina/complete/common.vim
@@ -41,6 +41,42 @@ function! gina#complete#common#command(arglead, cmdline, cursorpos) abort
   return gina#util#filter(a:arglead, command_names, '^_')
 endfunction
 
+function! gina#complete#common#raw_command(arglead, cmdline, cursorpos) abort
+  return gina#util#filter(a:arglead, [
+        \ 'add',
+        \ 'bisect',
+        \ 'branch',
+        \ 'checkout',
+        \ 'clone',
+        \ 'commit',
+        \ 'diff',
+        \ 'fetch',
+        \ 'grep',
+        \ 'init',
+        \ 'log',
+        \ 'merge',
+        \ 'mv',
+        \ 'pull',
+        \ 'push',
+        \ 'rebase',
+        \ 'reset',
+        \ 'restore',
+        \ 'rm',
+        \ 'show',
+        \ 'status',
+        \ 'switch',
+        \ 'tag',
+        \])
+endfunction
+
+function! gina#complete#common#remote(arglead, cmdline, cursorpos) abort
+  let git = gina#core#get_or_fail()
+  let result = gina#process#call(git, ['remote'])
+  if result.status
+    return []
+  endif
+  return gina#util#filter(a:arglead, result.stdout)
+endfunction
 
 " Private --------------------------------------------------------------------
 function! s:get_cache() abort


### PR DESCRIPTION
I implemented cmdline-completion for these git raw commands:

- `fetch`
- `pull`
- `push`
- `switch`

As a side effect, cmdline-completion now works for any of the gina commands by the existing corresponding `gina#command#{scheme}#complete()` function.

This PR may close #260.